### PR TITLE
[REVIEW] Remove old instructions from benchmark_runner bash script

### DIFF
--- a/tpcx_bb/benchmark_runner.sh
+++ b/tpcx_bb/benchmark_runner.sh
@@ -4,12 +4,6 @@
 
 # Benchmarking runner shell script
 
-# Example Usage
-# ./runner.sh --data_dir=new/data/dir --dask_dir=/dask/dir --file_format=parquet --spark_schema_dir=schema/dir --pool_mode=True --pool_size='1kB'
-# Args that are not supplied will use the default.
-# The first argument differentiates between which version of the queries to run (blazing vs dask_cudf) implementations,
-
-
 ARGS=${*:2}
 
 if [ $1 = "blazing" ]; then


### PR DESCRIPTION
This PR:
- Removes out of date instructions for running the `benchmark_runnner` bash script. This is covered in the README.