### PR TITLE
[REVIEW] Switch rmm.device_array to numba.cuda.device_array

### DIFF
--- a/tpcx_bb/queries/q03/tpcx_bb_query_03.py
+++ b/tpcx_bb/queries/q03/tpcx_bb_query_03.py
@@ -28,7 +28,6 @@ from distributed import wait
 import numpy as np
 
 from numba import cuda
-import rmm
 import glob
 from dask import delayed
 
@@ -99,7 +98,7 @@ def pre_repartition_task(wcs_fn, item_df, wcs_tstamp_min):
 
 def reduction_function(df, item_df_filtered):
     """
-         Combines all the reduction ops into a single frame 
+         Combines all the reduction ops into a single frame
     """
     product_view_results = apply_find_items_viewed(df, item_mappings=item_df_filtered)
 
@@ -176,7 +175,7 @@ def apply_find_items_viewed(df, item_mappings):
     size = len(sample)
 
     # we know this can be int32, since it's going to contain item_sks
-    out_arr = rmm.device_array(size * N, dtype=df["wcs_item_sk"].dtype)
+    out_arr = cuda.device_array(size * N, dtype=df["wcs_item_sk"].dtype)
 
     find_items_viewed_before_purchase_kernel.forall(size)(
         sample["relevant_idx_pos"],

--- a/tpcx_bb/queries/q11/tpcx_bb_query_11.py
+++ b/tpcx_bb/queries/q11/tpcx_bb_query_11.py
@@ -24,8 +24,7 @@ from xbb_tools.utils import (
 )
 from xbb_tools.readers import build_reader
 
-import rmm
-
+from numba import cuda
 import numpy as np
 
 cli_args = tpcxbb_argparser()
@@ -61,7 +60,7 @@ def read_tables():
 
 # Utility function for datestring -> days
 def convert_datestring_to_days(df, date_col="d_date", date_format="%Y-%m-%d"):
-    datetime_array = rmm.device_array(len(df), dtype=np.int64)
+    datetime_array = cuda.device_array(len(df), dtype=np.int64)
     df[date_col].str.timestamp2int(
         format=date_format, units="D", devptr=datetime_array.device_ctypes_pointer.value
     )

--- a/tpcx_bb/queries/q22/tpcx_bb_query_22.py
+++ b/tpcx_bb/queries/q22/tpcx_bb_query_22.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-import rmm
+from numba import cuda
 import numpy as np
 import sys
 
@@ -38,7 +38,7 @@ def inventory_before_after(df, date):
 
 
 def convert_datestring_to_days(df, date_col="d_date", date_format="%Y-%m-%d"):
-    datetime_array = rmm.device_array(len(df), dtype=np.int64)
+    datetime_array = cuda.device_array(len(df), dtype=np.int64)
     df[date_col].str.timestamp2int(
         format=date_format, units="D", devptr=datetime_array.device_ctypes_pointer.value
     )

--- a/tpcx_bb/queries/q25/tpcx_bb_query_25.py
+++ b/tpcx_bb/queries/q25/tpcx_bb_query_25.py
@@ -18,8 +18,7 @@ import sys
 
 
 import numpy as np
-import rmm
-
+from numba import cuda
 
 from xbb_tools.utils import (
     benchmark,
@@ -83,7 +82,7 @@ def convert_datestring_to_days(df, date_col="d_date", date_format="%Y-%m-%d"):
     """
     Utility to convert datestring to int representing days
     """
-    datetime_array = rmm.device_array(len(df), dtype=np.int64)
+    datetime_array = cuda.device_array(len(df), dtype=np.int64)
     df[date_col].str.timestamp2int(
         format=date_format, units="D", devptr=datetime_array.device_ctypes_pointer.value
     )

--- a/tpcx_bb/queries/q26/tpcx_bb_query_26.py
+++ b/tpcx_bb/queries/q26/tpcx_bb_query_26.py
@@ -18,8 +18,7 @@ import sys
 
 
 import numpy as np
-import rmm
-
+from numba import cuda
 
 from xbb_tools.utils import (
     benchmark,
@@ -72,7 +71,7 @@ def convert_datestring_to_days(df, date_col="d_date", date_format="%Y-%m-%d"):
     """
     Utility to convert datestring to int representing days
     """
-    datetime_array = rmm.device_array(len(df), dtype=np.int64)
+    datetime_array = cuda.device_array(len(df), dtype=np.int64)
     df[date_col].str.timestamp2int(
         format=date_format, units="D", devptr=datetime_array.device_ctypes_pointer.value
     )

--- a/tpcx_bb/xbb_tools/text_vectorizers/dist_hashing_vectorizer.py
+++ b/tpcx_bb/xbb_tools/text_vectorizers/dist_hashing_vectorizer.py
@@ -17,7 +17,7 @@
 import numpy as np
 import cupy as cp
 
-import rmm
+from numba import cuda
 
 from cupyx.scipy.sparse import csr_matrix
 
@@ -134,7 +134,7 @@ def str_token_to_string_id_hash(token_sr, n_features):
         Returns a hashed series of the provided strings
     """
     import cudf
-    str_hash_array = rmm.device_array(len(token_sr), dtype=np.uint32)
+    str_hash_array = cuda.device_array(len(token_sr), dtype=np.uint32)
     token_sr.str.hash(devptr=str_hash_array.device_ctypes_pointer.value)
     # upcasting because we dont support unsigned ints currently
     # see github issue:https://github.com/rapidsai/cudf/issues/2819


### PR DESCRIPTION
This PR:
- Updates all calls to `rmm.device_array` to use `numba.cuda.device_array`, as we're phasing out the RMM wrapper. See https://github.com/rapidsai/rmm/issues/180 for the discussion about phasing out `rmm.device_array`

We should also define a single `convert_datestring_to_days` function and import it within each query. This can be done in a follow-up PR.