### PR TITLE
[REVIEW] Use config for q18 bsql sentiment path

### DIFF
--- a/tpcx_bb/queries/q18/tpcx_bb_query_18_sql.py
+++ b/tpcx_bb/queries/q18/tpcx_bb_query_18_sql.py
@@ -243,9 +243,10 @@ def main(data_dir, client, bc, config):
     # This txt file comes from the official TPCx-BB kit
     # We extracted it from bigbenchqueriesmr.jar
     # Need to pass the absolute path for this txt file
-    bc.create_table('sent_df', os.getcwd() + "/negativeSentiment.txt",
-                    names=['sentiment_word'],
-                    dtype=['str'])
+    sentiment_dir = "/".join(
+        config["data_dir"].split("/")[:-3] + ["sentiment_files"])
+    bc.create_table('sent_df', sentiment_dir + "/negativeSentiment.txt",
+                    names=['sentiment_word'], dtype=['str'])
     bc.create_table('word_df', word_df)
     bc.create_table('sentences', sentences)
     bc.create_table('temp_table2', temp_table2)


### PR DESCRIPTION
This PR:
- Switches BSQL Q18 to assume the sentiment text files are in the data directory, and grab them from the configuration.

This closes #81 