### PR TITLE
[REVIEW] BlazinqSQL q08: using ORDER BY to distribute better the data

### DIFF
--- a/tpcx_bb/queries/q08/tpcx_bb_query_08_sql.py
+++ b/tpcx_bb/queries/q08/tpcx_bb_query_08_sql.py
@@ -199,10 +199,12 @@ def main(data_dir, client, bc, config):
         INNER JOIN web_page_2 ON wcs_web_page_sk = wp_web_page_sk
         WHERE wcs_user_sk IS NOT NULL
         AND wcs_click_date_sk BETWEEN {q08_start_dt} AND {q08_end_dt}
+        --in the future we want to remove this ORDER BY
         ORDER BY wcs_user_sk
     """
     merged_df = bc.sql(query_2)
 
+    merged_df = merged_df.repartition(columns=["wcs_user_sk"])
     merged_df["review_flag"] = merged_df.wp_type_codes == REVIEW_CAT_CODE
 
     prepped = merged_df.map_partitions(

--- a/tpcx_bb/queries/q08/tpcx_bb_query_08_sql.py
+++ b/tpcx_bb/queries/q08/tpcx_bb_query_08_sql.py
@@ -199,10 +199,10 @@ def main(data_dir, client, bc, config):
         INNER JOIN web_page_2 ON wcs_web_page_sk = wp_web_page_sk
         WHERE wcs_user_sk IS NOT NULL
         AND wcs_click_date_sk BETWEEN {q08_start_dt} AND {q08_end_dt}
+        ORDER BY wcs_user_sk
     """
     merged_df = bc.sql(query_2)
 
-    merged_df = merged_df.repartition(columns=["wcs_user_sk"])
     merged_df["review_flag"] = merged_df.wp_type_codes == REVIEW_CAT_CODE
 
     prepped = merged_df.map_partitions(


### PR DESCRIPTION
This PR avoids  `MemoryError: std::bad_alloc: CUDA error at: /home/christianc/conda/envs/bsql-tpcx/include/rmm/mr/device/cuda_memory_resource.hpp68: cudaErrorMemoryAllocation out of memory` at sf 10K

Just tested at sf **1K** on the **dgx201**. Took 21 s

```
(bsql-tpcx-bb) christianc@rl-dgx2-d17-u05-rapids-dgx201:~/tpcx-bb/tpcx_bb/queries/q08$ python tpcx_bb_query_08_sql.py --config_file=/home/christianc/yaml_dir/validation_1k_config.yaml
Using default arguments
Connected to tcp://10.150.162.27:8786
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.google.protobuf.UnsafeUtil (file:/home/christianc/miniconda3/envs/bsql-tpcx-bb/lib/blazingsql-algebra.jar) to field java.nio.Buffer.address
WARNING: Please consider reporting this to the maintainers of com.google.protobuf.UnsafeUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
BlazingContext ready
/home/christianc/miniconda3/envs/bsql-tpcx-bb/lib/python3.7/site-packages/distributed/worker.py:3385: UserWarning: Large object of size 2.28 MB detected in task graph: 
  ('get_element-941ef8b9486b45c74c230f0fc8ffda3b', E ... 'from_delayed')
Consider scattering large objects ahead of time
with client.scatter to reduce scheduler burden and 
keep data on workers

    future = client.submit(func, big_data)    # bad

    big_future = client.scatter(big_data)     # good
    future = client.submit(func, big_future)  # good
  % (format_bytes(len(b)), s)
Standard ETL Query
/home/christianc/miniconda3/envs/bsql-tpcx-bb/lib/python3.7/site-packages/pandas/util/__init__.py:12: FutureWarning: pandas.util.testing is deprecated. Use the functions in the public API at pandas.testing instead.
  import pandas.util.testing
Correctness Assertion True
```

Also tested on the **RAPLAB** at sf **10K**. Took 60 s

```
(bsql-tpcx) christianc@rl-dgx-d19-u12-rapids-dgx103:~/tpcx-bb/tpcx_bb/queries/q08$ python tpcx_bb_query_08_sql.py --config_file=../../benchmark_runner/benchmark_config.yaml
Using default arguments
Connected to tcp://172.16.8.158:8786
BlazingContext ready
/home/christianc/conda/envs/bsql-tpcx/lib/python3.7/site-packages/distributed/worker.py:3385: UserWarning: Large object of size 3.53 MB detected in task graph: 
  ('get_element-d19b8b71def4938bf004b809fee67b33', E ... 'from_delayed')
Consider scattering large objects ahead of time
with client.scatter to reduce scheduler burden and 
keep data on workers

    future = client.submit(func, big_data)    # bad

    big_future = client.scatter(big_data)     # good
    future = client.submit(func, big_future)  # good
  % (format_bytes(len(b)), s)
```