### PR TITLE
[REVIEW] BlazingSQL q28: Using bc.partition() instead of ORDER BY

### DIFF
--- a/tpcx_bb/queries/q28/tpcx_bb_query_28_sql.py
+++ b/tpcx_bb/queries/q28/tpcx_bb_query_28_sql.py
@@ -316,9 +316,12 @@ def main(data_dir, client, bc, config):
         FROM product_reviews
         WHERE mod(pr_review_sk, 10) IN (0)
         AND pr_review_content IS NOT NULL
-        ORDER BY pr_review_sk
+        -- in a near future we want to use ORDER BY again
+        --ORDER BY pr_review_sk
     """
     test_data = bc.sql(query1)
+    # in a near future we want to reuse ORDER BY instead of bc.partition()
+    test_data = bc.partition(test_data, by=["pr_review_sk"])
 
     # 90 % of data
     query2 = """
@@ -329,9 +332,11 @@ def main(data_dir, client, bc, config):
         FROM product_reviews
         WHERE mod(pr_review_sk, 10) IN (1,2,3,4,5,6,7,8,9)
         AND pr_review_content IS NOT NULL
-        ORDER BY pr_review_sk
+        --ORDER BY pr_review_sk
     """
     train_data = bc.sql(query2)
+    # in a near future we want to reuse ORDER BY instead of bc.partition()
+    train_data = bc.partition(train_data, by=["pr_review_sk"])
 
     final_data, acc, prec, cmat = post_etl_processing(
         client=client, train_data=train_data, test_data=test_data


### PR DESCRIPTION
This PR uses `bc.partition()` statement instead of `ORDER BY`. For now we have detect a sort of issue when using ORDER BY that in  a future we will handle better.
More details:   https://github.com/BlazingDB/blazingsql/blob/branch-0.15/pyblazing/pyblazing/apiv2/context.py#L2102