### PR TITLE
[REVIEW] BlazingSQL 02: Apply CAST to the first SQL

### DIFF
--- a/tpcx_bb/queries/q02/tpcx_bb_query_02_sql.py
+++ b/tpcx_bb/queries/q02/tpcx_bb_query_02_sql.py
@@ -44,8 +44,8 @@ def main(data_dir, client, bc, config):
 
     query_1 = """
         SELECT
-            wcs_user_sk,
-            wcs_item_sk,
+            CAST( wcs_user_sk AS INTEGER) AS wcs_user_sk,
+            CAST( wcs_item_sk AS INTEGER) AS wcs_item_sk,
             (wcs_click_date_sk * 86400 + wcs_click_time_sk) AS tstamp_inSec
         FROM web_clickstreams
         WHERE wcs_item_sk IS NOT NULL

--- a/tpcx_bb/queries/q02/tpcx_bb_query_02_sql.py
+++ b/tpcx_bb/queries/q02/tpcx_bb_query_02_sql.py
@@ -61,6 +61,7 @@ def main(data_dir, client, bc, config):
     )
 
     bc.create_table('session_df', session_df)
+    del wcs_result
 
     last_query = f"""
         WITH item_df AS (
@@ -69,7 +70,6 @@ def main(data_dir, client, bc, config):
             WHERE wcs_item_sk = {q02_item_sk}
         )
         SELECT sd.wcs_item_sk as item_sk_1,
-            {q02_item_sk} as item_sk_2,
             count(sd.wcs_item_sk) as cnt
         FROM session_df sd
         INNER JOIN item_df id
@@ -81,6 +81,9 @@ def main(data_dir, client, bc, config):
         LIMIT {q02_limit}
     """
     result = bc.sql(last_query)
+    result["item_sk_2"] = q02_item_sk
+    result_order = ["item_sk_1", "item_sk_2", "cnt"]
+    result = result[result_order]
     return result
 
 

--- a/tpcx_bb/queries/q02/tpcx_bb_query_02_sql.py
+++ b/tpcx_bb/queries/q02/tpcx_bb_query_02_sql.py
@@ -61,7 +61,9 @@ def main(data_dir, client, bc, config):
     )
 
     bc.create_table('session_df', session_df)
+
     del wcs_result
+    del session_df
 
     last_query = f"""
         WITH item_df AS (


### PR DESCRIPTION
This PR add a couple of `CAST()` for both `wcs_user_sk` & `wcs_item_sk` columns in the first SQL statement. Also deletes both    `wcs_result` & `session_df`  ` dask_cudf.DataFrames` after create the `session_df` table. Finally, removes the constant column called `item_sk_2` from the last SQL statement.