### PR TITLE
[REVIEW] Use the filename passed into load_query for file loading

### DIFF
--- a/tpcx_bb/benchmark_runner.py
+++ b/tpcx_bb/benchmark_runner.py
@@ -19,7 +19,7 @@ bsql_qnums = [get_qnum_from_filename(x.split("/")[-1]) for x in bsql_query_files
 
 def load_query(qnum, fn):
     import importlib, types
-    loader = importlib.machinery.SourceFileLoader(qnum, f"queries/q{qnum}/tpcx_bb_query_{qnum}.py")
+    loader = importlib.machinery.SourceFileLoader(qnum, fn)
     mod = types.ModuleType(loader.name)
     loader.exec_module(mod)
     return mod.main


### PR DESCRIPTION
This PR:
- Fixes a bug in the benchmark runner's `load_query` function that makes it hard coded to pure dask queries