### PR TITLE
[REVIEW] Persist() and bc.drop_table() functions when source is a dask_cudf.DataFrame

### DIFF
--- a/tpcx_bb/queries/q01/tpcx_bb_query_01_sql.py
+++ b/tpcx_bb/queries/q01/tpcx_bb_query_01_sql.py
@@ -27,6 +27,7 @@ from xbb_tools.utils import (
     run_query,
 )
 
+from dask.distributed import wait
 
 # -------- Q1 -----------
 q01_i_category_id_IN = "1, 2, 3"
@@ -53,6 +54,8 @@ def main(data_dir, client, bc, config):
     """
     result_distinct = bc.sql(query_distinct)
 
+    result_distinct = result_distinct.persist()
+    wait(result_distinct)
     bc.create_table("distinct_table", result_distinct)
 
     query = f"""
@@ -73,6 +76,8 @@ def main(data_dir, client, bc, config):
         LIMIT {q01_limit}
     """
     result = bc.sql(query)
+
+    bc.drop_table("distinct_table")
     return result
 
 

--- a/tpcx_bb/queries/q03/tpcx_bb_query_03_sql.py
+++ b/tpcx_bb/queries/q03/tpcx_bb_query_03_sql.py
@@ -26,6 +26,7 @@ from xbb_tools.utils import (
     run_query,
 )
 
+from dask.distributed import wait
 
 # -------- Q03 -----------
 q03_days_in_sec_before_purchase = 864000
@@ -139,14 +140,15 @@ def main(data_dir, client, bc, config):
     """
     item_df = bc.sql(query_1)
 
+    item_df = item_df.persist()
+    wait(item_df)
     bc.create_table("item_df", item_df)
 
     query_2 = """
         SELECT CAST(w.wcs_user_sk AS INTEGER) as wcs_user_sk,
             wcs_click_date_sk * 86400 + wcs_click_time_sk AS tstamp,
             CAST(w.wcs_item_sk AS INTEGER) as wcs_item_sk,
-            COALESCE(w.wcs_sales_sk, 0) as wcs_sales_sk,
-            i.i_category_id
+            CAST(COALESCE(w.wcs_sales_sk, 0) AS INTEGER) as wcs_sales_sk
         FROM web_clickstreams AS w
         INNER JOIN item_df AS i ON w.wcs_item_sk = i.i_item_sk
         WHERE w.wcs_user_sk IS NOT NULL
@@ -166,7 +168,10 @@ def main(data_dir, client, bc, config):
         apply_find_items_viewed, item_mappings=item_df_filtered
     )
     del merged_df
-
+    del item_df_filtered
+    
+    product_view_results = product_view_results.persist()
+    wait(product_view_results)
     bc.create_table('product_result', product_view_results)
 
     last_query = f"""
@@ -179,6 +184,9 @@ def main(data_dir, client, bc, config):
         LIMIT {q03_limit}
     """
     result = bc.sql(last_query)
+
+    bc.drop_table("item_df")
+    bc.drop_table("product_result")
     return result
 
 

--- a/tpcx_bb/queries/q03/tpcx_bb_query_03_sql.py
+++ b/tpcx_bb/queries/q03/tpcx_bb_query_03_sql.py
@@ -190,6 +190,7 @@ def main(data_dir, client, bc, config):
     result = bc.sql(last_query)
 
     bc.drop_table("product_result")
+    del product_view_results
     return result
 
 

--- a/tpcx_bb/queries/q03/tpcx_bb_query_03_sql.py
+++ b/tpcx_bb/queries/q03/tpcx_bb_query_03_sql.py
@@ -167,11 +167,15 @@ def main(data_dir, client, bc, config):
     product_view_results = merged_df.map_partitions(
         apply_find_items_viewed, item_mappings=item_df_filtered
     )
-    del merged_df
-    del item_df_filtered
     
     product_view_results = product_view_results.persist()
     wait(product_view_results)
+
+    bc.drop_table("item_df")
+    del item_df
+    del merged_df
+    del item_df_filtered
+
     bc.create_table('product_result', product_view_results)
 
     last_query = f"""
@@ -185,7 +189,6 @@ def main(data_dir, client, bc, config):
     """
     result = bc.sql(last_query)
 
-    bc.drop_table("item_df")
     bc.drop_table("product_result")
     return result
 

--- a/tpcx_bb/queries/q04/tpcx_bb_query_04_sql.py
+++ b/tpcx_bb/queries/q04/tpcx_bb_query_04_sql.py
@@ -26,6 +26,7 @@ from xbb_tools.utils import (
     run_query,
 )
 
+from dask.distributed import wait
 
 def abandonedShoppingCarts(df, DYNAMIC_CAT_CODE, ORDER_CAT_CODE):
     import cudf
@@ -111,6 +112,8 @@ def main(data_dir, client, bc, config):
     cols_2_keep = ["wp_web_page_sk", "wp_type_codes"]
     wp = wp[cols_2_keep]
 
+    wp = wp.persist()
+    wait(wp)
     bc.create_table('web_page', wp)
 
     query = """
@@ -138,6 +141,7 @@ def main(data_dir, client, bc, config):
 
     result = result.compute()
     result_df = cudf.DataFrame({"sum(pagecount)/count(*)": [result]})
+    bc.drop_table("web_page")
     return result_df
 
 

--- a/tpcx_bb/queries/q08/tpcx_bb_query_08_sql.py
+++ b/tpcx_bb/queries/q08/tpcx_bb_query_08_sql.py
@@ -222,8 +222,6 @@ def main(data_dir, client, bc, config):
     unique_review_sales = sessionized.map_partitions(
         get_unique_sales_keys_from_sessions, review_cat_code=REVIEW_CAT_CODE
     )
-
-    del merged_df
     
     unique_review_sales = unique_review_sales.to_frame()
 

--- a/tpcx_bb/queries/q08/tpcx_bb_query_08_sql.py
+++ b/tpcx_bb/queries/q08/tpcx_bb_query_08_sql.py
@@ -207,6 +207,9 @@ def main(data_dir, client, bc, config):
     """
     merged_df = bc.sql(query_2)
 
+    bc.drop_table("web_page_2")
+    del web_page_df
+
     merged_df = merged_df.repartition(columns=["wcs_user_sk"])
     merged_df["review_flag"] = merged_df.wp_type_codes == REVIEW_CAT_CODE
 
@@ -220,6 +223,8 @@ def main(data_dir, client, bc, config):
         get_unique_sales_keys_from_sessions, review_cat_code=REVIEW_CAT_CODE
     )
 
+    del merged_df
+    
     unique_review_sales = unique_review_sales.to_frame()
 
     unique_review_sales = unique_review_sales.persist()
@@ -241,7 +246,6 @@ def main(data_dir, client, bc, config):
     """
     result = bc.sql(last_query)
 
-    bc.drop_table("web_page_2")
     bc.drop_table("reviews")
     return result
 

--- a/tpcx_bb/queries/q08/tpcx_bb_query_08_sql.py
+++ b/tpcx_bb/queries/q08/tpcx_bb_query_08_sql.py
@@ -28,6 +28,7 @@ from xbb_tools.utils import (
     run_query,
 )
 
+from dask.distributed import wait
 
 # -------- Q8 -----------
 q08_SECONDS_BEFORE_PURCHASE = 259200
@@ -187,6 +188,8 @@ def main(data_dir, client, bc, config):
     web_page_newcols = ["wp_web_page_sk", "wp_type_codes"]
     web_page_df = web_page_df[web_page_newcols]
 
+    web_page_df = web_page_df.persist()
+    wait(web_page_df)
     bc.create_table('web_page_2', web_page_df)
 
     query_2 = f"""
@@ -219,6 +222,8 @@ def main(data_dir, client, bc, config):
 
     unique_review_sales = unique_review_sales.to_frame()
 
+    unique_review_sales = unique_review_sales.persist()
+    wait(unique_review_sales)
     bc.create_table("reviews", unique_review_sales)
     last_query = f"""
         SELECT
@@ -236,6 +241,8 @@ def main(data_dir, client, bc, config):
     """
     result = bc.sql(last_query)
 
+    bc.drop_table("web_page_2")
+    bc.drop_table("reviews")
     return result
 
 

--- a/tpcx_bb/queries/q13/tpcx_bb_query_13_sql.py
+++ b/tpcx_bb/queries/q13/tpcx_bb_query_13_sql.py
@@ -30,6 +30,7 @@ from xbb_tools.utils import (
     run_query,
 )
 
+from dask.distributed import wait
 
 def read_tables(data_dir, bc):
     bc.create_table("date_dim", data_dir + "/date_dim/*.parquet")
@@ -58,6 +59,8 @@ def main(data_dir, client, bc, config):
 	"""
     temp_table1 = bc.sql(query_1)
 
+    temp_table1 = temp_table1.persist()
+    wait(temp_table1)
     bc.create_table("temp_table1", temp_table1)
     query_2 = """
 		SELECT
@@ -76,6 +79,8 @@ def main(data_dir, client, bc, config):
 	"""
     temp_table2 = bc.sql(query_2)
 
+    temp_table2 = temp_table2.persist()
+    wait(temp_table2)
     bc.create_table("temp_table2", temp_table2)
     query = """
 		SELECT
@@ -96,8 +101,10 @@ def main(data_dir, client, bc, config):
 			c_last_name
 		LIMIT 100
     """
-
     result = bc.sql(query)
+
+    bc.drop_table("temp_table1")
+    bc.drop_table("temp_table2")
     return result
 
 

--- a/tpcx_bb/queries/q18/tpcx_bb_query_18_sql.py
+++ b/tpcx_bb/queries/q18/tpcx_bb_query_18_sql.py
@@ -233,6 +233,12 @@ def main(data_dir, client, bc, config):
     """
     temp_table2 = bc.sql(query_3)
 
+    bc.drop_table("stores_with_regression")
+    del stores_with_regression
+
+    bc.drop_table("combined")
+    del combined
+
     # REAL QUERY
     sentences = no_nulls.map_partitions(create_sentences_from_reviews)
 
@@ -307,8 +313,6 @@ def main(data_dir, client, bc, config):
     """
     result = bc.sql(query_4)
 
-    bc.drop_table("stores_with_regression")
-    bc.drop_table("combined")
     bc.drop_table("word_df")
     bc.drop_table("sentences")
     bc.drop_table("temp_table2")

--- a/tpcx_bb/queries/q18/tpcx_bb_query_18_sql.py
+++ b/tpcx_bb/queries/q18/tpcx_bb_query_18_sql.py
@@ -30,6 +30,7 @@ from xbb_tools.utils import (
     run_query,
 )
 
+from dask.distributed import wait
 
 # -------- Q18 -----------
 q18_startDate = "2001-05-02"
@@ -215,7 +216,12 @@ def main(data_dir, client, bc, config):
         "s_store_name"
     ] = stores_with_regression.s_store_name.str.lower()
 
+    stores_with_regression = stores_with_regression.persist()
+    wait(stores_with_regression)
     bc.create_table("stores_with_regression", stores_with_regression)
+    
+    combined = combined.persist()
+    wait(combined)
     bc.create_table("combined", combined)
 
     query_3 = """
@@ -250,8 +256,17 @@ def main(data_dir, client, bc, config):
         names=["sentiment_word"],
         dtype=["str"],
     )
+
+    word_df = word_df.persist()
+    wait(word_df)
     bc.create_table("word_df", word_df)
+    
+    sentences = sentences.persist()
+    wait(sentences)
     bc.create_table("sentences", sentences)
+    
+    temp_table2 = temp_table2.persist()
+    wait(temp_table2)
     bc.create_table("temp_table2", temp_table2)
 
     query_4 = """
@@ -291,6 +306,12 @@ def main(data_dir, client, bc, config):
         ORDER BY s_name, r_date, r_sentence, sentiment_word
     """
     result = bc.sql(query_4)
+
+    bc.drop_table("stores_with_regression")
+    bc.drop_table("combined")
+    bc.drop_table("word_df")
+    bc.drop_table("sentences")
+    bc.drop_table("temp_table2")
     return result
 
 

--- a/tpcx_bb/queries/q23/tpcx_bb_query_23_sql.py
+++ b/tpcx_bb/queries/q23/tpcx_bb_query_23_sql.py
@@ -85,6 +85,12 @@ def main(data_dir, client, bc, config):
     """
     std_result = bc.sql(query_3)
 
+    bc.drop_table("inv_dates")
+    del inv_dates_result
+
+    bc.drop_table("mean_df")
+    del mean_result
+
     std_result = std_result.persist()
     wait(std_result)
     bc.create_table('iteration', std_result)
@@ -97,6 +103,8 @@ def main(data_dir, client, bc, config):
         WHERE (q_std / q_mean) >= {q23_coefficient}
     """
     std_result = bc.sql(query_4)
+
+    bc.drop_table("iteration")
 
     std_result = std_result.persist()
     wait(std_result)
@@ -118,9 +126,6 @@ def main(data_dir, client, bc, config):
     """
     result = bc.sql(query)
 
-    bc.drop_table("inv_dates")
-    bc.drop_table("mean_df")
-    bc.drop_table("iteration")
     bc.drop_table("temp_table")
     return result
 

--- a/tpcx_bb/queries/q23/tpcx_bb_query_23_sql.py
+++ b/tpcx_bb/queries/q23/tpcx_bb_query_23_sql.py
@@ -25,6 +25,7 @@ from xbb_tools.utils import (
     run_query,
 )
 
+from dask.distributed import wait
 
 # -------- Q23 -----------
 q23_year = 2001
@@ -52,6 +53,8 @@ def main(data_dir, client, bc, config):
     """
     inv_dates_result = bc.sql(query_1)
 
+    inv_dates_result = inv_dates_result.persist()
+    wait(inv_dates_result)
     bc.create_table('inv_dates', inv_dates_result)
     query_2 = """
         SELECT inv_warehouse_sk,
@@ -63,6 +66,8 @@ def main(data_dir, client, bc, config):
     """
     mean_result = bc.sql(query_2)
 
+    mean_result = mean_result.persist()
+    wait(mean_result)
     bc.create_table('mean_df', mean_result)
     query_3 = """
         SELECT id.inv_warehouse_sk,
@@ -80,6 +85,8 @@ def main(data_dir, client, bc, config):
     """
     std_result = bc.sql(query_3)
 
+    std_result = std_result.persist()
+    wait(std_result)
     bc.create_table('iteration', std_result)
     query_4 = f"""
         SELECT inv_warehouse_sk,
@@ -91,6 +98,8 @@ def main(data_dir, client, bc, config):
     """
     std_result = bc.sql(query_4)
 
+    std_result = std_result.persist()
+    wait(std_result)
     bc.create_table('temp_table', std_result)
     query = f"""
         SELECT inv1.inv_warehouse_sk,
@@ -108,6 +117,11 @@ def main(data_dir, client, bc, config):
             inv1.inv_item_sk
     """
     result = bc.sql(query)
+
+    bc.drop_table("inv_dates")
+    bc.drop_table("mean_df")
+    bc.drop_table("iteration")
+    bc.drop_table("temp_table")
     return result
 
 

--- a/tpcx_bb/queries/q27/tpcx_bb_query_27_sql.py
+++ b/tpcx_bb/queries/q27/tpcx_bb_query_27_sql.py
@@ -79,9 +79,7 @@ def main(data_dir, client, bc, config):
     sentences["x"] = 1
     sentences["sentence_tokenized_global_pos"] = sentences.x.cumsum()
     del sentences["x"]
-
-    sentences = sentences.persist()
-    wait(sentences)
+    del product_reviews_df
 
     # Do the NER
     sentences = sentences.to_dask_dataframe()
@@ -99,6 +97,7 @@ def main(data_dir, client, bc, config):
         global_position_column="sentence_tokenized_global_pos",
         delimiter="é",
     )
+    del sentences
 
     # recombine
     repeated_names = repeated_names.persist()
@@ -122,6 +121,8 @@ def main(data_dir, client, bc, config):
 
     bc.drop_table("repeated_names")
     bc.drop_table("ner_parsed")
+    del ner_parsed
+    del repeated_names
     return recombined
 
 

--- a/tpcx_bb/queries/q30/tpcx_bb_query_30_sql.py
+++ b/tpcx_bb/queries/q30/tpcx_bb_query_30_sql.py
@@ -30,6 +30,7 @@ from xbb_tools.sessionization import (
     get_pairs
 )
 
+from dask.distributed import wait
 
 # -------- Q30 -----------
 # session timeout in secs
@@ -53,6 +54,8 @@ def main(data_dir, client, bc, config):
     """
     item_df = bc.sql(query_1)
 
+    item_df = item_df.persist()
+    wait(item_df)
     bc.create_table("item_df", item_df)
 
     query_2 = """
@@ -79,6 +82,8 @@ def main(data_dir, client, bc, config):
         output_col_2="category_id_2")
     del distinct_session_df
 
+    pair_df = pair_df.persist()
+    wait(pair_df)
     bc.create_table('pair_df', pair_df)
 
     last_query = f"""
@@ -91,6 +96,9 @@ def main(data_dir, client, bc, config):
         LIMIT {q30_limit}
     """
     result = bc.sql(last_query)
+
+    bc.drop_table("item_df")
+    bc.drop_table("pair_df")
     return result
 
 

--- a/tpcx_bb/queries/q30/tpcx_bb_query_30_sql.py
+++ b/tpcx_bb/queries/q30/tpcx_bb_query_30_sql.py
@@ -70,6 +70,9 @@ def main(data_dir, client, bc, config):
     """
     merged_df = bc.sql(query_2)
 
+    bc.drop_table("item_df")
+    del item_df
+
     distinct_session_df = merged_df.map_partitions(get_distinct_sessions,
             keep_cols=["wcs_user_sk", "i_category_id"],
             time_out=q30_session_timeout_inSec)
@@ -97,7 +100,6 @@ def main(data_dir, client, bc, config):
     """
     result = bc.sql(last_query)
 
-    bc.drop_table("item_df")
     bc.drop_table("pair_df")
     return result
 


### PR DESCRIPTION
This PR adds a `persist()` call just before` bc.create_table()` when the table comes from `dask_cudf.dataFrame` . As well, call to the `bc.drop_table()` function respectively for those tables that were created from a` dask_cudf.DataFrame`.
Additional:  
Q03: 
* Remove  `i.i_category_id` from the first SQL statement (unused)
* Adds a `CAST` to the `COALESCE()` from the first SQL statement