### PR TITLE
[REVIEW] Update blazing params, add ORDER BY instead of bc.partition() for q10, q18 and q19

### DIFF
--- a/tpcx_bb/queries/q10/tpcx_bb_query_10_sql.py
+++ b/tpcx_bb/queries/q10/tpcx_bb_query_10_sql.py
@@ -49,13 +49,9 @@ def main(data_dir, client, bc, config):
             pr_review_sk
         FROM product_reviews
         where pr_review_content IS NOT NULL
+        ORDER BY pr_item_sk, pr_review_content, pr_review_sk
     """
     product_reviews_df = bc.sql(query_1)
-
-    product_reviews_df = product_reviews_df.persist()
-    wait(product_reviews_df)
-    product_reviews_df = bc.partition(product_reviews_df,
-        by=["pr_item_sk", "pr_review_content", "pr_review_sk"])
 
     product_reviews_df[
         "pr_review_content"

--- a/tpcx_bb/queries/q10/tpcx_bb_query_10_sql.py
+++ b/tpcx_bb/queries/q10/tpcx_bb_query_10_sql.py
@@ -52,6 +52,8 @@ def main(data_dir, client, bc, config):
     """
     product_reviews_df = bc.sql(query_1)
 
+    product_reviews_df = product_reviews_df.persist()
+    wait(product_reviews_df)
     product_reviews_df = bc.partition(product_reviews_df,
         by=["pr_item_sk", "pr_review_content", "pr_review_sk"])
 
@@ -137,8 +139,12 @@ def main(data_dir, client, bc, config):
     result = bc.sql(query)
 
     bc.drop_table("product_reviews_df")
+    del product_reviews_df
     bc.drop_table("sentences")
+    del sentences
     bc.drop_table("word_df")
+    del word_df
+
     return result
 
 

--- a/tpcx_bb/queries/q18/tpcx_bb_query_18_sql.py
+++ b/tpcx_bb/queries/q18/tpcx_bb_query_18_sql.py
@@ -172,14 +172,9 @@ def main(data_dir, client, bc, config):
             CAST(pr_review_sk AS INTEGER) AS pr_review_sk
         FROM product_reviews
         WHERE pr_review_content IS NOT NULL
+        ORDER BY pr_review_date, pr_review_content, pr_review_sk
     """
     no_nulls = bc.sql(query_2)
-
-    no_nulls = no_nulls.persist()
-    wait(no_nulls)
-    no_nulls = bc.partition(
-        no_nulls, by=["pr_review_date", "pr_review_content", "pr_review_sk"]
-    )
 
     targets = (
         stores_with_regression.s_store_name.str.lower()

--- a/tpcx_bb/queries/q18/tpcx_bb_query_18_sql.py
+++ b/tpcx_bb/queries/q18/tpcx_bb_query_18_sql.py
@@ -174,6 +174,9 @@ def main(data_dir, client, bc, config):
         WHERE pr_review_content IS NOT NULL
     """
     no_nulls = bc.sql(query_2)
+
+    no_nulls = no_nulls.persist()
+    wait(no_nulls)
     no_nulls = bc.partition(
         no_nulls, by=["pr_review_date", "pr_review_content", "pr_review_sk"]
     )
@@ -314,8 +317,11 @@ def main(data_dir, client, bc, config):
     result = bc.sql(query_4)
 
     bc.drop_table("word_df")
+    del word_df
     bc.drop_table("sentences")
+    del sentences
     bc.drop_table("temp_table2")
+    del temp_table2
     return result
 
 

--- a/tpcx_bb/queries/q19/tpcx_bb_query_19_sql.py
+++ b/tpcx_bb/queries/q19/tpcx_bb_query_19_sql.py
@@ -91,14 +91,9 @@ def main(data_dir, client, bc, config):
                 ((sr_item_qty + wr_item_qty)/2) ) <= 0.1
         )
         SELECT * FROM extract_sentiment
+        ORDER BY pr_item_sk, pr_review_content, pr_review_sk
     """
     merged_df = bc.sql(query)
-
-    merged_df = merged_df.persist()
-    wait(merged_df)
-    merged_df = bc.partition(
-        merged_df, by=["pr_item_sk", "pr_review_content", "pr_review_sk"]
-    )
 
     # second step -- Sentiment Word Extraction
     merged_df["pr_review_sk"] = merged_df["pr_review_sk"].astype("int32")

--- a/tpcx_bb/queries/q19/tpcx_bb_query_19_sql.py
+++ b/tpcx_bb/queries/q19/tpcx_bb_query_19_sql.py
@@ -93,6 +93,9 @@ def main(data_dir, client, bc, config):
         SELECT * FROM extract_sentiment
     """
     merged_df = bc.sql(query)
+
+    merged_df = merged_df.persist()
+    wait(merged_df)
     merged_df = bc.partition(
         merged_df, by=["pr_item_sk", "pr_review_content", "pr_review_sk"]
     )
@@ -165,8 +168,12 @@ def main(data_dir, client, bc, config):
     result = bc.sql(query)
 
     bc.drop_table("sentences_df")
+    del sentences
     bc.drop_table("word_df")
+    del word_df
     bc.drop_table("merged_df")
+    del merged_df
+
     return result
 
 

--- a/tpcx_bb/xbb_tools/cluster_startup.py
+++ b/tpcx_bb/xbb_tools/cluster_startup.py
@@ -34,16 +34,23 @@ def get_config_options():
     """
     config_options = {}
     config_options['JOIN_PARTITION_SIZE_THRESHOLD'] = os.environ.get("JOIN_PARTITION_SIZE_THRESHOLD", 300000000)
-    config_options['BLAZING_DEVICE_MEM_CONSUMPTION_THRESHOLD'] = os.environ.get("BLAZING_DEVICE_MEM_CONSUMPTION_THRESHOLD", 0.8)
-    config_options['BLAZING_LOGGING_DIRECTORY'] = os.environ.get("BLAZING_LOGGING_DIRECTORY", 'blazing_log')
     config_options['MAX_DATA_LOAD_CONCAT_CACHE_BYTE_SIZE'] =  os.environ.get("MAX_DATA_LOAD_CONCAT_CACHE_BYTE_SIZE", 300000000)
-    config_options['MAX_KERNEL_RUN_THREADS'] = os.environ.get("MAX_KERNEL_RUN_THREADS", 16)
-    config_options['MAX_NUM_ORDER_BY_PARTITIONS_PER_NODE'] = os.environ.get("MAX_NUM_ORDER_BY_PARTITIONS_PER_NODE", 8)
-    config_options['ORDER_BY_SAMPLES_RATIO'] = os.environ.get("ORDER_BY_SAMPLES_RATIO", 0.1)
+    config_options['BLAZING_DEVICE_MEM_CONSUMPTION_THRESHOLD'] = os.environ.get("BLAZING_DEVICE_MEM_CONSUMPTION_THRESHOLD", 0.6)
+    config_options['BLAZ_HOST_MEM_CONSUMPTION_THRESHOLD'] = os.environ.get("BLAZ_HOST_MEM_CONSUMPTION_THRESHOLD", 0.6)
+    config_options['MAX_KERNEL_RUN_THREADS'] = os.environ.get("MAX_KERNEL_RUN_THREADS", 3)
+    config_options['TABLE_SCAN_KERNEL_NUM_THREADS'] = os.environ.get("TABLE_SCAN_KERNEL_NUM_THREADS", 1)
+    config_options['MAX_NUM_ORDER_BY_PARTITIONS_PER_NODE'] = os.environ.get("MAX_NUM_ORDER_BY_PARTITIONS_PER_NODE", 20)
+    config_options['ORDER_BY_SAMPLES_RATIO'] = os.environ.get("ORDER_BY_SAMPLES_RATIO", 0.0002)
     config_options['NUM_BYTES_PER_ORDER_BY_PARTITION'] = os.environ.get("NUM_BYTES_PER_ORDER_BY_PARTITION", 400000000)
+    config_options['MAX_SEND_MESSAGE_THREADS'] = os.environ.get("MAX_SEND_MESSAGE_THREADS", 20)
+    config_options['MEMORY_MONITOR_PERIOD'] = os.environ.get("MEMORY_MONITOR_PERIOD", 50)
+    config_options['TRANSPORT_BUFFER_BYTE_SIZE'] = os.environ.get("TRANSPORT_BUFFER_BYTE_SIZE", 10485760) # 10 MBs
+    config_options['BLAZING_LOGGING_DIRECTORY'] = os.environ.get("BLAZING_LOGGING_DIRECTORY", 'blazing_log')
     config_options['BLAZING_CACHE_DIRECTORY'] = os.environ.get("BLAZING_CACHE_DIRECTORY", '/tmp/')
+    config_options['LOGGING_LEVEL'] = os.environ.get("LOGGING_LEVEL", "debug")
 
     return config_options
+
 
 def attach_to_cluster(config, create_blazing_context=False):
     """Attaches to an existing cluster if available.
@@ -64,6 +71,7 @@ def attach_to_cluster(config, create_blazing_context=False):
             url = content.split("Scheduler ")[1].split(":" + str(port))[0]
             client = Client(address=f"{url}:{port}")
             print(f"Connected to {url}:{port}")
+            config["protocol"] = str(url)[0:3]
         except requests.exceptions.ConnectionError as e:
             sys.exit(
                 f"Unable to connect to existing dask scheduler dashboard to determine cluster type: {e}"

--- a/tpcx_bb/xbb_tools/cluster_startup.py
+++ b/tpcx_bb/xbb_tools/cluster_startup.py
@@ -47,7 +47,7 @@ def get_config_options():
     config_options['TRANSPORT_BUFFER_BYTE_SIZE'] = os.environ.get("TRANSPORT_BUFFER_BYTE_SIZE", 10485760) # 10 MBs
     config_options['BLAZING_LOGGING_DIRECTORY'] = os.environ.get("BLAZING_LOGGING_DIRECTORY", 'blazing_log')
     config_options['BLAZING_CACHE_DIRECTORY'] = os.environ.get("BLAZING_CACHE_DIRECTORY", '/tmp/')
-    config_options['LOGGING_LEVEL'] = os.environ.get("LOGGING_LEVEL", "debug")
+    config_options['LOGGING_LEVEL'] = os.environ.get("LOGGING_LEVEL", "trace")
 
     return config_options
 


### PR DESCRIPTION
This PR update some BlazingSQL params as add some others. 
This PR also avoid the use of `bc.partition()` , instead of that uses `ORDER BY` statement. As well, add a couple of `del`s  after drop tables. Finally add a line of code ( `config["protocol"] = str(url)[0:3]` ) just for tracking protocool.
Tested at sf **1K** on the **dgx201**

```
(bsql-tpcx) christianc@rl-dgx2-d17-u05-rapids-dgx201:~/tpcx-bb/tpcx_bb$ python benchmark_runner.py --config_file=/home/christianc/yaml_dir/benchmark_1k_w_validation.yaml 
['10', '18', '19']
Using default arguments
Connected to tcp://10.150.162.27:8786
BlazingContext ready
Blazing Queries
10
/home/christianc/miniconda3/envs/bsql-tpcx/lib/python3.7/site-packages/cudf/core/column/string.py:700: UserWarning: `n` parameter is not supported when `pat` and `repl` are list-like inputs
  "`n` parameter is not supported when "
/home/christianc/miniconda3/envs/bsql-tpcx/lib/python3.7/site-packages/cudf/core/column/string.py:700: UserWarning: `n` parameter is not supported when `pat` and `repl` are list-like inputs
  "`n` parameter is not supported when "
Sentiment Analysis Query
96.73181084836891% overlap with 6329652 rows (RAPIDS denominator)
97.47078162728856% overlap with 6281664 rows (Spark denominator)
Correctness Assertion True
18
/home/christianc/miniconda3/envs/bsql-tpcx/lib/python3.7/site-packages/cudf/core/column/string.py:700: UserWarning: `n` parameter is not supported when `pat` and `repl` are list-like inputs
  "`n` parameter is not supported when "
Sentiment Analysis Query
95.8086979543316% overlap with 1533533 rows (RAPIDS denominator)
95.90632204766145% overlap with 1531972 rows (Spark denominator)
Correctness Assertion True
19
/home/christianc/miniconda3/envs/bsql-tpcx/lib/python3.7/site-packages/cudf/core/column/string.py:700: UserWarning: `n` parameter is not supported when `pat` and `repl` are list-like inputs
  "`n` parameter is not supported when "
Sentiment Analysis Query
92.88446915692424% overlap with 84168 rows (RAPIDS denominator)
93.39489654513308% overlap with 83708 rows (Spark denominator)
Correctness Assertion True
```