### PR TITLE
[REVIEW] BlazingSQL: Q02 - Remove ORDER BY tstamp

### DIFF
--- a/tpcx_bb/queries/q02/tpcx_bb_query_02_sql.py
+++ b/tpcx_bb/queries/q02/tpcx_bb_query_02_sql.py
@@ -44,13 +44,13 @@ def main(data_dir, client, bc, config):
 
     query_1 = """
         SELECT
-            CAST( wcs_user_sk AS INTEGER) AS wcs_user_sk,
-            CAST( wcs_item_sk AS INTEGER) AS wcs_item_sk,
+            CAST(wcs_user_sk AS INTEGER) AS wcs_user_sk,
+            CAST(wcs_item_sk AS INTEGER) AS wcs_item_sk,
             (wcs_click_date_sk * 86400 + wcs_click_time_sk) AS tstamp_inSec
         FROM web_clickstreams
         WHERE wcs_item_sk IS NOT NULL
         AND   wcs_user_sk IS NOT NULL
-        ORDER BY wcs_user_sk, tstamp_inSec
+        ORDER BY wcs_user_sk
     """
     wcs_result = bc.sql(query_1)
 


### PR DESCRIPTION
This PR just remove `ORDER BY tstamp_inSec` as it is not necessary.