### PR TITLE
[REVIEW] Use DataFrame constructor to convert cupy arrays into dataframes

### DIFF
--- a/tpcx_bb/queries/q18/tpcx_bb_query_18.py
+++ b/tpcx_bb/queries/q18/tpcx_bb_query_18.py
@@ -117,7 +117,7 @@ def find_targets_in_reviews_helper(ddf, targets, str_col_name="pr_review_content
     lowered = ddf[str_col_name].str.lower()
 
     ## TODO: Do the replace/any in cupy land before going to cuDF
-    resdf = cudf.DataFrame.from_gpu_matrix(
+    resdf = cudf.DataFrame(
         cp.asarray(
             find_multiple.find_multiple(lowered._column, targets._column)
         ).reshape(-1, len(targets))

--- a/tpcx_bb/queries/q18/tpcx_bb_query_18_sql.py
+++ b/tpcx_bb/queries/q18/tpcx_bb_query_18_sql.py
@@ -82,7 +82,7 @@ def find_targets_in_reviews_helper(ddf, targets, str_col_name="pr_review_content
     lowered = ddf[str_col_name].str.lower()
 
     ## TODO: Do the replace/any in cupy land before going to cuDF
-    resdf = cudf.DataFrame.from_gpu_matrix(
+    resdf = cudf.DataFrame(
         cp.asarray(
             find_multiple.find_multiple(lowered._column, targets._column)
         ).reshape(-1, len(targets))


### PR DESCRIPTION
This PR:
- Updates q18 to use the DataFrame constructor instead of `from_gpu_matrix` to convert a cupy array into a DataFrame


Verified correct at SF1K.

This closes https://github.com/rapidsai/tpcx-bb/issues/18