### PR TITLE
[REVIEW] Switch hash repartition to shuffle API and fix dask incorrect dask queries due to upstream changes

### DIFF
--- a/tpcx_bb/queries/q02/tpcx_bb_query_02.py
+++ b/tpcx_bb/queries/q02/tpcx_bb_query_02.py
@@ -115,7 +115,7 @@ def main(client, config):
     # AND   wcs_user_sk IS NOT NULL
 
     f_wcs_df = wcs_df.map_partitions(pre_repartition_task)
-    f_wcs_df = f_wcs_df.repartition(columns=["wcs_user_sk"])
+    f_wcs_df = f_wcs_df.shuffle(on=["wcs_user_sk"])
 
     ### Main Query
     # SELECT

--- a/tpcx_bb/queries/q03/tpcx_bb_query_03.py
+++ b/tpcx_bb/queries/q03/tpcx_bb_query_03.py
@@ -252,7 +252,7 @@ def main(client, config):
 
     merged_df = dask_cudf.from_delayed(task_ls, meta=meta_df)
 
-    merged_df = merged_df.repartition(columns="wcs_user_sk")
+    merged_df = merged_df.shuffle(on="wcs_user_sk")
 
     meta_d = {
         "i_item_sk": np.ones(1, dtype=merged_df["wcs_item_sk"].dtype),

--- a/tpcx_bb/queries/q04/tpcx_bb_query_04.py
+++ b/tpcx_bb/queries/q04/tpcx_bb_query_04.py
@@ -131,7 +131,7 @@ def main(client, config):
     keep_cols = ["wcs_user_sk", "tstamp_inSec", "wcs_web_page_sk"]
     f_wcs_df = f_wcs_df[keep_cols]
 
-    f_wcs_df = f_wcs_df.repartition(columns=["wcs_user_sk"])
+    f_wcs_df = f_wcs_df.shuffle(on=["wcs_user_sk"])
 
     # Convert wp_type to categorical and get cat_id of review and dynamic type
     wp["wp_type"] = wp["wp_type"].map_partitions(lambda ser: ser.astype("category"))

--- a/tpcx_bb/queries/q08/tpcx_bb_query_08.py
+++ b/tpcx_bb/queries/q08/tpcx_bb_query_08.py
@@ -269,7 +269,7 @@ def main(client, config):
     meta_df = cudf.DataFrame(meta_d)
     merged_df = dask_cudf.from_delayed(task_ls, meta=meta_df)
 
-    merged_df = merged_df.repartition(columns=["wcs_user_sk"])
+    merged_df = merged_df.shuffle(on=["wcs_user_sk"])
     reviewed_sales = merged_df.map_partitions(
         reduction_function,
         REVIEW_CAT_CODE,

--- a/tpcx_bb/queries/q08/tpcx_bb_query_08_sql.py
+++ b/tpcx_bb/queries/q08/tpcx_bb_query_08_sql.py
@@ -210,7 +210,7 @@ def main(data_dir, client, bc, config):
     bc.drop_table("web_page_2")
     del web_page_df
 
-    merged_df = merged_df.repartition(columns=["wcs_user_sk"])
+    merged_df = merged_df.shuffle(on=["wcs_user_sk"])
     merged_df["review_flag"] = merged_df.wp_type_codes == REVIEW_CAT_CODE
 
     prepped = merged_df.map_partitions(

--- a/tpcx_bb/queries/q16/tpcx_bb_query_16.py
+++ b/tpcx_bb/queries/q16/tpcx_bb_query_16.py
@@ -236,7 +236,7 @@ def main(client, config):
     ## group by logic
     group_cols = ["w_state_code", "i_item_id_code"]
 
-    agg_df = sales_before_after_df.groupby(group_cols).agg(
+    agg_df = sales_before_after_df.groupby(group_cols, sort=True).agg(
         {"sales_before": "sum", "sales_after": "sum"}
     )
     agg_df = agg_df.reset_index(drop=False)

--- a/tpcx_bb/queries/q20/tpcx_bb_query_20.py
+++ b/tpcx_bb/queries/q20/tpcx_bb_query_20.py
@@ -121,7 +121,7 @@ def main(client, config):
     unique_sales = store_sales_df[
         ["ss_ticket_number", "ss_customer_sk"]
     ].map_partitions(lambda df: df.drop_duplicates())
-    unique_sales = unique_sales.repartition(columns=["ss_customer_sk"])
+    unique_sales = unique_sales.shuffle(on=["ss_customer_sk"])
     unique_sales = unique_sales.map_partitions(lambda df: df.drop_duplicates())
 
     unique_sales = unique_sales.persist()

--- a/tpcx_bb/queries/q22/tpcx_bb_query_22.py
+++ b/tpcx_bb/queries/q22/tpcx_bb_query_22.py
@@ -133,7 +133,7 @@ def main(client, config):
     output_table = output_table[keep_columns]
 
     output_table = (
-        output_table.groupby(by=["w_warehouse_name", "i_item_id"])
+        output_table.groupby(by=["w_warehouse_name", "i_item_id"], sort=True)
         .agg({"inv_before": "sum", "inv_after": "sum"})
         .reset_index()
     )

--- a/tpcx_bb/queries/q25/tpcx_bb_query_25.py
+++ b/tpcx_bb/queries/q25/tpcx_bb_query_25.py
@@ -71,7 +71,7 @@ def agg_count_distinct(df, group_key, counted_key, client):
     unique_df = df[[group_key, counted_key]].map_partitions(
         lambda df: df.drop_duplicates()
     )
-    unique_df = unique_df.repartition(columns=[group_key])
+    unique_df = unique_df.shuffle(on=[group_key])
     unique_df = unique_df.map_partitions(lambda df: df.drop_duplicates())
 
     return unique_df.groupby(group_key)[counted_key].count(split_every=2)
@@ -93,7 +93,9 @@ def get_clusters(client, ml_input_df):
     )
     output["label"] = labels_final.reset_index()[0]
 
-    # Based on CDH6.1 q25-result formatting
+    # Sort based on CDH6.1 q25-result formatting
+    output = output.sort_values(["cid"])
+
     results_dict["cid_labels"] = output
     return results_dict
 

--- a/tpcx_bb/queries/q26/tpcx_bb_query_26.py
+++ b/tpcx_bb/queries/q26/tpcx_bb_query_26.py
@@ -81,6 +81,9 @@ def get_clusters(client, kmeans_input_df):
     )
     output["label"] = labels_final.reset_index()[0]
 
+    # Sort based on CDH6.1 q25-result formatting
+    output = output.sort_values(["ss_customer_sk"])
+
     # Based on CDH6.1 q26-result formatting
     results_dict["cid_labels"] = output
     return results_dict

--- a/tpcx_bb/queries/q26/tpcx_bb_query_26.py
+++ b/tpcx_bb/queries/q26/tpcx_bb_query_26.py
@@ -81,7 +81,7 @@ def get_clusters(client, kmeans_input_df):
     )
     output["label"] = labels_final.reset_index()[0]
 
-    # Sort based on CDH6.1 q25-result formatting
+    # Sort based on CDH6.1 q26-result formatting
     output = output.sort_values(["ss_customer_sk"])
 
     # Based on CDH6.1 q26-result formatting

--- a/tpcx_bb/queries/q29/tpcx_bb_query_29.py
+++ b/tpcx_bb/queries/q29/tpcx_bb_query_29.py
@@ -101,7 +101,7 @@ def main(client, config):
         dask_profile=config["dask_profile"],
     )
     ### setting index on ws_order_number
-    ws_df = ws_df.repartition(columns=["ws_order_number"])
+    ws_df = ws_df.shuffle(on=["ws_order_number"])
     ### at sf-100k we will have max of 17M rows and 17 M rows with 2 columns, 1 part is very reasonable
     item_df = item_df.repartition(npartitions=1)
 

--- a/tpcx_bb/queries/q30/tpcx_bb_query_30.py
+++ b/tpcx_bb/queries/q30/tpcx_bb_query_30.py
@@ -128,7 +128,7 @@ def main(client, config):
     merged_df = dask_cudf.from_delayed(task_ls, meta=meta_df)
 
     ### that the click for each user ends up at the same partition
-    merged_df = merged_df.repartition(columns=["wcs_user_sk"])
+    merged_df = merged_df.shuffle(on=["wcs_user_sk"])
 
     ### Main Query
     ### sessionize logic.

--- a/tpcx_bb/xbb_tools/merge_util.py
+++ b/tpcx_bb/xbb_tools/merge_util.py
@@ -36,8 +36,8 @@ def hash_merge(
     if npartitions is None:
         npartitions = max(lhs.npartitions, rhs.npartitions)
 
-    lhs2 = lhs.repartition(columns=left_on, npartitions=npartitions)
-    rhs2 = rhs.repartition(columns=right_on, npartitions=npartitions)
+    lhs2 = lhs.shuffle(on=left_on, npartitions=npartitions)
+    rhs2 = rhs.shuffle(on=right_on, npartitions=npartitions)
 
     kwargs = dict(
         how=how,

--- a/tpcx_bb/xbb_tools/utils.py
+++ b/tpcx_bb/xbb_tools/utils.py
@@ -455,6 +455,7 @@ def calculate_label_overlap_percent(spark_labels, rapids_labels):
     rapids_labels.columns = ["cid", "label"]
 
     # assert that we clustered the same IDs
+    rapids_labels = rapids_labels.reset_index(drop=True)
     assert spark_labels.cid.equals(rapids_labels.cid)
 
     rapids_counts_normalized = rapids_labels.label.value_counts(


### PR DESCRIPTION
This PR:
- Switches all hash repartitions to use the `df.shuffle` API
- Updates dask queries that are now failing due to upstream changes
- Updates the clustering query labels check to ignore the index, which is immaterial but misaligned due to the dask-cudf reader vs dask.dataframe


This closes #112, closes #115, and closes #117 

All queries verified at SF1K