### PR TITLE
[REVIEW] Adding more BSQL params

### DIFF
--- a/tpcx_bb/xbb_tools/cluster_startup.py
+++ b/tpcx_bb/xbb_tools/cluster_startup.py
@@ -42,12 +42,15 @@ def get_config_options():
     config_options['MAX_NUM_ORDER_BY_PARTITIONS_PER_NODE'] = os.environ.get("MAX_NUM_ORDER_BY_PARTITIONS_PER_NODE", 20)
     config_options['ORDER_BY_SAMPLES_RATIO'] = os.environ.get("ORDER_BY_SAMPLES_RATIO", 0.0002)
     config_options['NUM_BYTES_PER_ORDER_BY_PARTITION'] = os.environ.get("NUM_BYTES_PER_ORDER_BY_PARTITION", 400000000)
+    config_options['MAX_ORDER_BY_SAMPLES_PER_NODE'] = os.environ.get("MAX_ORDER_BY_SAMPLES_PER_NODE", 10000)
     config_options['MAX_SEND_MESSAGE_THREADS'] = os.environ.get("MAX_SEND_MESSAGE_THREADS", 20)
     config_options['MEMORY_MONITOR_PERIOD'] = os.environ.get("MEMORY_MONITOR_PERIOD", 50)
     config_options['TRANSPORT_BUFFER_BYTE_SIZE'] = os.environ.get("TRANSPORT_BUFFER_BYTE_SIZE", 10485760) # 10 MBs
+    config_options['TRANSPORT_POOL_NUM_BUFFERS'] = os.environ.get("TRANSPORT_POOL_NUM_BUFFERS", 100)
     config_options['BLAZING_LOGGING_DIRECTORY'] = os.environ.get("BLAZING_LOGGING_DIRECTORY", 'blazing_log')
     config_options['BLAZING_CACHE_DIRECTORY'] = os.environ.get("BLAZING_CACHE_DIRECTORY", '/tmp/')
     config_options['LOGGING_LEVEL'] = os.environ.get("LOGGING_LEVEL", "trace")
+    config_options['MAX_JOIN_SCATTER_MEM_OVERHEAD'] = os.environ.get("MAX_JOIN_SCATTER_MEM_OVERHEAD", 500000000)
 
     return config_options
 


### PR DESCRIPTION
This PR adds three BSQL params:
`MAX_ORDER_BY_SAMPLES_PER_NODE`: The max number order by samples to capture per node.
                    default: 10000
`TRANSPORT_POOL_NUM_BUFFERS`: The number of buffers in the punned buffer memory pool.
                    default: 100 buffers
`MAX_JOIN_SCATTER_MEM_OVERHEAD`: The bigger this value, the more  likely one of the tables of join will be scattered to all  the nodes, instead of doing a standard hash based partitioning shuffle. Value is in bytes.
                    default: 500000000

To read about these, and other parameters, check: https://docs.blazingdb.com/docs/config_options