### PR TITLE
[REVIEW] Pin to known working dask/distributed commits with rapids 0.16

### DIFF
--- a/conda/rapids-tpcx-bb.yml
+++ b/conda/rapids-tpcx-bb.yml
@@ -35,5 +35,5 @@ dependencies:
   - pip:
     - transformers
     - jupyter-server-proxy
-    - git+https://github.com/dask/dask.git
-    - git+https://github.com/dask/distributed.git
+    - git+https://github.com/dask/dask.git@2b45fdb9bcf4a98e54b8fa2c7c3da1410a73bea3
+    - git+https://github.com/dask/distributed.git@2b43b402c19b278a1e2fe7e1bf7718452b2fe007


### PR DESCRIPTION
This PR:
- Avoids the issue in https://github.com/rapidsai/tpcx-bb/issues/121 by pinning to known working commits for Dask and Distributed