### PR TITLE
[REVIEW] Fix logic and update load test script

### DIFF
--- a/tpcx_bb/queries/load_test/tpcx_bb_load_test.py
+++ b/tpcx_bb/queries/load_test/tpcx_bb_load_test.py
@@ -133,7 +133,7 @@ def repartition(table, outdir, npartitions=None, chunksize=None, compression="sn
 def main(client, config):
     # location you want to write Parquet versions of the table data
     data_dir = config["data_dir"].split('parquet_')[0]
-    outdir = f"{data_dir}/parquet_{part_size}gb_test/"
+    outdir = f"{data_dir}/parquet_{part_size}gb/"
 
     total = 0
     for table in tables:


### PR DESCRIPTION
This PR:
- Fixes the logic error in the load test script's handling of the `web_clickstreams` table
- Updates the argument parser to be consistent with the queries; this was left out as an oversight during a refactor

Tested this just now converting the raw SF1K CSV tables (data + data_refresh) to 3GB parquet files on a DGX-1 with 32GB V100s in a fresh conda environment made from the tpcx-bb.yml in the repository.

This closes https://github.com/rapidsai/tpcx-bb/issues/123