### PR TITLE
[REVIEW] Default cluster to TCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ In `cluster_configuration/cluster-startup.sh`:
     - Update `CONDA_ENV_PATH=...` to refer to your conda environment path.
     - Update `CONDA_ENV_NAME=...` to refer to the name of the conda environment you created, perhaps using the `yml` files provided in this repository.
     - Update `INTERFACE=...` to refer to the relevant network interface present on your cluster.
-    - Update `CLUSTER_MODE="NVLINK"` to refer to your communication method, either "TCP" or "NVLINK".
+    - Update `CLUSTER_MODE="TCP"` to refer to your communication method, either "TCP" or "NVLINK".
     - You may also need to change the `LOCAL_DIRECTORY` and `WORKER_DIR` depending on your filesystem. Make sure that these point to a location to which you have write access and that `LOCAL_DIRECTORY` is accessible from all nodes.
 
 

--- a/tpcx_bb/cluster_configuration/cluster-startup.sh
+++ b/tpcx_bb/cluster_configuration/cluster-startup.sh
@@ -1,6 +1,6 @@
 #NVLINK or TCP
 ROLE=$1
-CLUSTER_MODE="NVLINK"
+CLUSTER_MODE="TCP"
 USERNAME=$(whoami)
 
 MAX_SYSTEM_MEMORY=$(free -m | awk '/^Mem:/{print $2}')M


### PR DESCRIPTION
This PR:
- Updates the default cluster communication to be TCP while https://github.com/rapidsai/tpcx-bb/issues/126 is unresolved
- Updates the relevant portion of the README