### PR TITLE
[REVIEW] Fix unsafe string path concatenation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Note that this Conda environment needs to be replicated or installed manually on
 
 ## NLP Query Setup
 
-Queries 10, 18, and 19 depend on two static (negativeSentiment.txt, positiveSentiment.txt) files. As we cannot redistribute those files, you should [download the tpcx-bb toolkit](http://www.tpc.org/tpc_documents_current_versions/download_programs/tools-download-request5.asp?bm_type=TPCX-BB&bm_vers=1.3.1&mode=CURRENT-ONLY) and extract them to your shared filesystem:
+Queries 10, 18, and 19 depend on two static (negativeSentiment.txt, positiveSentiment.txt) files. As we cannot redistribute those files, you should [download the tpcx-bb toolkit](http://www.tpc.org/tpc_documents_current_versions/download_programs/tools-download-request5.asp?bm_type=TPCX-BB&bm_vers=1.3.1&mode=CURRENT-ONLY) and extract them to your data directory on your shared filesystem:
 ```
 jar xf bigbenchqueriesmr.jar
-cp tpcx-bb1.3.1/distributions/Resources/io/bigdatabenchmark/v1/queries/q10/*.txt ${DATA_DIR}/tpcx-bb/sentiment_files/
+cp tpcx-bb1.3.1/distributions/Resources/io/bigdatabenchmark/v1/queries/q10/*.txt ${DATA_DIR}/sentiment_files/
 ```
 
 For Query 27, we rely on [spacy](https://spacy.io/). To download the necessary language model after activating the Conda environment:

--- a/tpcx_bb/queries/q01/tpcx_bb_query_01_sql.py
+++ b/tpcx_bb/queries/q01/tpcx_bb_query_01_sql.py
@@ -38,8 +38,8 @@ q01_limit = 100
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("item", os.path.join(data_dir,  "/item/*.parquet"))
-    bc.create_table("store_sales", os.path.join(data_dir,  "/store_sales/*.parquet"))
+    bc.create_table("item", os.path.join(data_dir, "item/*.parquet"))
+    bc.create_table("store_sales", os.path.join(data_dir, "store_sales/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q01/tpcx_bb_query_01_sql.py
+++ b/tpcx_bb/queries/q01/tpcx_bb_query_01_sql.py
@@ -38,8 +38,8 @@ q01_limit = 100
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("item", data_dir + "/item/*.parquet")
-    bc.create_table("store_sales", data_dir + "/store_sales/*.parquet")
+    bc.create_table("item", os.path.join(data_dir,  "/item/*.parquet"))
+    bc.create_table("store_sales", os.path.join(data_dir,  "/store_sales/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q02/tpcx_bb_query_02_sql.py
+++ b/tpcx_bb/queries/q02/tpcx_bb_query_02_sql.py
@@ -16,6 +16,7 @@
 #
 
 import sys
+import os
 
 from xbb_tools.cluster_startup import attach_to_cluster
 
@@ -36,7 +37,7 @@ q02_session_timeout_inSec = 3600
 
 def read_tables(data_dir, bc):
     bc.create_table("web_clickstreams",
-                    data_dir + "web_clickstreams/*.parquet")
+                    os.path.join(data_dir, "web_clickstreams/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q03/tpcx_bb_query_03_sql.py
+++ b/tpcx_bb/queries/q03/tpcx_bb_query_03_sql.py
@@ -127,7 +127,7 @@ def apply_find_items_viewed(df, item_mappings):
 def read_tables(data_dir, bc):
     bc.create_table("web_clickstreams",
                     data_dir + "web_clickstreams/*.parquet")
-    bc.create_table("item", data_dir + "item/*.parquet")
+    bc.create_table("item", os.path.join(data_dir,  "item/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q03/tpcx_bb_query_03_sql.py
+++ b/tpcx_bb/queries/q03/tpcx_bb_query_03_sql.py
@@ -128,7 +128,7 @@ def apply_find_items_viewed(df, item_mappings):
 def read_tables(data_dir, bc):
     bc.create_table("web_clickstreams",
                     os.path.join(data_dir, "web_clickstreams/*.parquet"))
-    bc.create_table("item", os.path.join(data_dir,  "item/*.parquet"))
+    bc.create_table("item", os.path.join(data_dir, "item/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q03/tpcx_bb_query_03_sql.py
+++ b/tpcx_bb/queries/q03/tpcx_bb_query_03_sql.py
@@ -16,6 +16,7 @@
 #
 
 import sys
+import os
 
 from xbb_tools.cluster_startup import attach_to_cluster
 from numba import cuda
@@ -126,7 +127,7 @@ def apply_find_items_viewed(df, item_mappings):
 
 def read_tables(data_dir, bc):
     bc.create_table("web_clickstreams",
-                    data_dir + "web_clickstreams/*.parquet")
+                    os.path.join(data_dir, "web_clickstreams/*.parquet"))
     bc.create_table("item", os.path.join(data_dir,  "item/*.parquet"))
 
 

--- a/tpcx_bb/queries/q04/tpcx_bb_query_04_sql.py
+++ b/tpcx_bb/queries/q04/tpcx_bb_query_04_sql.py
@@ -16,6 +16,7 @@
 #
 
 import sys
+import os
 
 from xbb_tools.cluster_startup import attach_to_cluster
 from xbb_tools.sessionization import get_sessions
@@ -84,7 +85,7 @@ def reduction_function(df, keep_cols, DYNAMIC_CAT_CODE, ORDER_CAT_CODE):
 def read_tables(data_dir, bc):
     bc.create_table('web_page_wo_categorical', os.path.join(data_dir,  "web_page/*.parquet"))
     bc.create_table('web_clickstreams',
-                    data_dir + "web_clickstreams/*.parquet")
+                    os.path.join(data_dir, "web_clickstreams/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q04/tpcx_bb_query_04_sql.py
+++ b/tpcx_bb/queries/q04/tpcx_bb_query_04_sql.py
@@ -82,7 +82,7 @@ def reduction_function(df, keep_cols, DYNAMIC_CAT_CODE, ORDER_CAT_CODE):
 
 
 def read_tables(data_dir, bc):
-    bc.create_table('web_page_wo_categorical', data_dir + "web_page/*.parquet")
+    bc.create_table('web_page_wo_categorical', os.path.join(data_dir,  "web_page/*.parquet"))
     bc.create_table('web_clickstreams',
                     data_dir + "web_clickstreams/*.parquet")
 

--- a/tpcx_bb/queries/q04/tpcx_bb_query_04_sql.py
+++ b/tpcx_bb/queries/q04/tpcx_bb_query_04_sql.py
@@ -83,7 +83,7 @@ def reduction_function(df, keep_cols, DYNAMIC_CAT_CODE, ORDER_CAT_CODE):
 
 
 def read_tables(data_dir, bc):
-    bc.create_table('web_page_wo_categorical', os.path.join(data_dir,  "web_page/*.parquet"))
+    bc.create_table('web_page_wo_categorical', os.path.join(data_dir, "web_page/*.parquet"))
     bc.create_table('web_clickstreams',
                     os.path.join(data_dir, "web_clickstreams/*.parquet"))
 

--- a/tpcx_bb/queries/q05/tpcx_bb_query_05.py
+++ b/tpcx_bb/queries/q05/tpcx_bb_query_05.py
@@ -15,8 +15,7 @@
 #
 
 import sys
-
-
+import os
 import glob
 
 from xbb_tools.utils import (
@@ -31,11 +30,8 @@ from xbb_tools.cupy_metrics import cupy_conf_mat, cupy_precision_score
 import cupy as cp
 import numpy as np
 from dask import delayed
-
-
 import dask
 import pandas as pd
-
 from sklearn.metrics import roc_auc_score
 
 #
@@ -186,7 +182,7 @@ def main(client, config):
     keep_cols = ["i_item_sk", "i_category_id", "clicks_in_category"]
     item_ddf = item_ddf[keep_cols]
 
-    web_clickstream_flist = glob.glob(config["data_dir"] + "web_clickstreams/*.parquet")
+    web_clickstream_flist = glob.glob(os.path.join(config["data_dir"], "web_clickstreams/*.parquet"))
     n_workers = len(client.scheduler_info()["workers"])
     batchsize = len(web_clickstream_flist) // n_workers
     if batchsize < 1:

--- a/tpcx_bb/queries/q05/tpcx_bb_query_05_sql.py
+++ b/tpcx_bb/queries/q05/tpcx_bb_query_05_sql.py
@@ -44,11 +44,11 @@ convergence_tol = 1e-9
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("web_clickstreams", os.path.join(data_dir,  "web_clickstreams/*.parquet"))
-    bc.create_table("customer", os.path.join(data_dir,  "customer/*.parquet"))
-    bc.create_table("item", os.path.join(data_dir,  "item/*.parquet"))
+    bc.create_table("web_clickstreams", os.path.join(data_dir, "web_clickstreams/*.parquet"))
+    bc.create_table("customer", os.path.join(data_dir, "customer/*.parquet"))
+    bc.create_table("item", os.path.join(data_dir, "item/*.parquet"))
     bc.create_table(
-        "customer_demographics", os.path.join(data_dir,  "customer_demographics/*.parquet"
+        "customer_demographics", os.path.join(data_dir, "customer_demographics/*.parquet"
     ))
 
 

--- a/tpcx_bb/queries/q05/tpcx_bb_query_05_sql.py
+++ b/tpcx_bb/queries/q05/tpcx_bb_query_05_sql.py
@@ -49,7 +49,7 @@ def read_tables(data_dir, bc):
     bc.create_table("item", os.path.join(data_dir,  "item/*.parquet"))
     bc.create_table(
         "customer_demographics", os.path.join(data_dir,  "customer_demographics/*.parquet"
-    )
+    ))
 
 
 def build_and_predict_model(ml_input_df):

--- a/tpcx_bb/queries/q05/tpcx_bb_query_05_sql.py
+++ b/tpcx_bb/queries/q05/tpcx_bb_query_05_sql.py
@@ -44,11 +44,11 @@ convergence_tol = 1e-9
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("web_clickstreams", data_dir + "web_clickstreams/*.parquet")
-    bc.create_table("customer", data_dir + "customer/*.parquet")
-    bc.create_table("item", data_dir + "item/*.parquet")
+    bc.create_table("web_clickstreams", os.path.join(data_dir,  "web_clickstreams/*.parquet"))
+    bc.create_table("customer", os.path.join(data_dir,  "customer/*.parquet"))
+    bc.create_table("item", os.path.join(data_dir,  "item/*.parquet"))
     bc.create_table(
-        "customer_demographics", data_dir + "customer_demographics/*.parquet"
+        "customer_demographics", os.path.join(data_dir,  "customer_demographics/*.parquet"
     )
 
 

--- a/tpcx_bb/queries/q06/tpcx_bb_query_06_sql.py
+++ b/tpcx_bb/queries/q06/tpcx_bb_query_06_sql.py
@@ -33,10 +33,10 @@ q06_YEAR = 2001
 
 
 def read_tables(data_dir, bc):
-    bc.create_table('web_sales', os.path.join(data_dir,  "web_sales/*.parquet"))
-    bc.create_table('store_sales', os.path.join(data_dir,  "store_sales/*.parquet"))
-    bc.create_table('date_dim', os.path.join(data_dir,  "date_dim/*.parquet"))
-    bc.create_table('customer', os.path.join(data_dir,  "customer/*.parquet"))
+    bc.create_table('web_sales', os.path.join(data_dir, "web_sales/*.parquet"))
+    bc.create_table('store_sales', os.path.join(data_dir, "store_sales/*.parquet"))
+    bc.create_table('date_dim', os.path.join(data_dir, "date_dim/*.parquet"))
+    bc.create_table('customer', os.path.join(data_dir, "customer/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q06/tpcx_bb_query_06_sql.py
+++ b/tpcx_bb/queries/q06/tpcx_bb_query_06_sql.py
@@ -16,6 +16,7 @@
 #
 
 import sys
+import os
 
 from xbb_tools.cluster_startup import attach_to_cluster
 

--- a/tpcx_bb/queries/q06/tpcx_bb_query_06_sql.py
+++ b/tpcx_bb/queries/q06/tpcx_bb_query_06_sql.py
@@ -33,10 +33,10 @@ q06_YEAR = 2001
 
 
 def read_tables(data_dir, bc):
-    bc.create_table('web_sales', data_dir + "web_sales/*.parquet")
-    bc.create_table('store_sales', data_dir + "store_sales/*.parquet")
-    bc.create_table('date_dim', data_dir + "date_dim/*.parquet")
-    bc.create_table('customer', data_dir + "customer/*.parquet")
+    bc.create_table('web_sales', os.path.join(data_dir,  "web_sales/*.parquet"))
+    bc.create_table('store_sales', os.path.join(data_dir,  "store_sales/*.parquet"))
+    bc.create_table('date_dim', os.path.join(data_dir,  "date_dim/*.parquet"))
+    bc.create_table('customer', os.path.join(data_dir,  "customer/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q07/tpcx_bb_query_07_sql.py
+++ b/tpcx_bb/queries/q07/tpcx_bb_query_07_sql.py
@@ -32,11 +32,11 @@ from xbb_tools.utils import (
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("item", os.path.join(data_dir,  "/item/*.parquet"))
-    bc.create_table("customer", os.path.join(data_dir,  "/customer/*.parquet"))
-    bc.create_table("store_sales", os.path.join(data_dir,  "/store_sales/*.parquet"))
-    bc.create_table("date_dim", os.path.join(data_dir,  "/date_dim/*.parquet"))
-    bc.create_table("customer_address", os.path.join(data_dir,  "/customer_address/*.parquet"))
+    bc.create_table("item", os.path.join(data_dir, "item/*.parquet"))
+    bc.create_table("customer", os.path.join(data_dir, "customer/*.parquet"))
+    bc.create_table("store_sales", os.path.join(data_dir, "store_sales/*.parquet"))
+    bc.create_table("date_dim", os.path.join(data_dir, "date_dim/*.parquet"))
+    bc.create_table("customer_address", os.path.join(data_dir, "customer_address/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q07/tpcx_bb_query_07_sql.py
+++ b/tpcx_bb/queries/q07/tpcx_bb_query_07_sql.py
@@ -32,11 +32,11 @@ from xbb_tools.utils import (
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("item", data_dir + "/item/*.parquet")
-    bc.create_table("customer", data_dir + "/customer/*.parquet")
-    bc.create_table("store_sales", data_dir + "/store_sales/*.parquet")
-    bc.create_table("date_dim", data_dir + "/date_dim/*.parquet")
-    bc.create_table("customer_address", data_dir + "/customer_address/*.parquet")
+    bc.create_table("item", os.path.join(data_dir,  "/item/*.parquet"))
+    bc.create_table("customer", os.path.join(data_dir,  "/customer/*.parquet"))
+    bc.create_table("store_sales", os.path.join(data_dir,  "/store_sales/*.parquet"))
+    bc.create_table("date_dim", os.path.join(data_dir,  "/date_dim/*.parquet"))
+    bc.create_table("customer_address", os.path.join(data_dir,  "/customer_address/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q08/tpcx_bb_query_08.py
+++ b/tpcx_bb/queries/q08/tpcx_bb_query_08.py
@@ -15,8 +15,7 @@
 #
 
 import sys
-
-
+import os
 import glob
 
 from xbb_tools.utils import (
@@ -251,7 +250,7 @@ def main(client, config):
     web_page_newcols = ["wp_web_page_sk", "wp_type_codes"]
     web_page_df = web_page_df[web_page_newcols]
 
-    web_clickstream_flist = glob.glob(config["data_dir"] + "web_clickstreams/*.parquet")
+    web_clickstream_flist = glob.glob(os.path.join(config["data_dir"], "web_clickstreams/*.parquet"))
 
     task_ls = [
         delayed(etl_wcs)(

--- a/tpcx_bb/queries/q08/tpcx_bb_query_08_sql.py
+++ b/tpcx_bb/queries/q08/tpcx_bb_query_08_sql.py
@@ -16,6 +16,7 @@
 #
 
 import sys
+import os
 
 from xbb_tools.cluster_startup import attach_to_cluster
 import cupy as cp

--- a/tpcx_bb/queries/q08/tpcx_bb_query_08_sql.py
+++ b/tpcx_bb/queries/q08/tpcx_bb_query_08_sql.py
@@ -140,10 +140,10 @@ def prep_for_sessionization(df, review_cat_code):
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("web_clickstreams", os.path.join(data_dir,  "/web_clickstreams/*.parquet"))
-    bc.create_table("web_sales", os.path.join(data_dir,  "/web_sales/*.parquet"))
-    bc.create_table("web_page", os.path.join(data_dir,  "/web_page/*.parquet"))
-    bc.create_table("date_dim", os.path.join(data_dir,  "/date_dim/*.parquet"))
+    bc.create_table("web_clickstreams", os.path.join(data_dir, "web_clickstreams/*.parquet"))
+    bc.create_table("web_sales", os.path.join(data_dir, "web_sales/*.parquet"))
+    bc.create_table("web_page", os.path.join(data_dir, "web_page/*.parquet"))
+    bc.create_table("date_dim", os.path.join(data_dir, "date_dim/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q08/tpcx_bb_query_08_sql.py
+++ b/tpcx_bb/queries/q08/tpcx_bb_query_08_sql.py
@@ -140,10 +140,10 @@ def prep_for_sessionization(df, review_cat_code):
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("web_clickstreams", data_dir + "/web_clickstreams/*.parquet")
-    bc.create_table("web_sales", data_dir + "/web_sales/*.parquet")
-    bc.create_table("web_page", data_dir + "/web_page/*.parquet")
-    bc.create_table("date_dim", data_dir + "/date_dim/*.parquet")
+    bc.create_table("web_clickstreams", os.path.join(data_dir,  "/web_clickstreams/*.parquet"))
+    bc.create_table("web_sales", os.path.join(data_dir,  "/web_sales/*.parquet"))
+    bc.create_table("web_page", os.path.join(data_dir,  "/web_page/*.parquet"))
+    bc.create_table("date_dim", os.path.join(data_dir,  "/date_dim/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q09/tpcx_bb_query_09_sql.py
+++ b/tpcx_bb/queries/q09/tpcx_bb_query_09_sql.py
@@ -60,13 +60,13 @@ q09_part3_sales_price_max = 200
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("store_sales", os.path.join(data_dir,  "/store_sales/*.parquet"))
-    bc.create_table("customer_address", os.path.join(data_dir,  "/customer_address/*.parquet"))
+    bc.create_table("store_sales", os.path.join(data_dir, "store_sales/*.parquet"))
+    bc.create_table("customer_address", os.path.join(data_dir, "customer_address/*.parquet"))
     bc.create_table(
-        "customer_demographics", os.path.join(data_dir,  "/customer_demographics/*.parquet"
+        "customer_demographics", os.path.join(data_dir, "customer_demographics/*.parquet"
     ))
-    bc.create_table("date_dim", os.path.join(data_dir,  "/date_dim/*.parquet"))
-    bc.create_table("store", os.path.join(data_dir,  "/store/*.parquet"))
+    bc.create_table("date_dim", os.path.join(data_dir, "date_dim/*.parquet"))
+    bc.create_table("store", os.path.join(data_dir, "store/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q09/tpcx_bb_query_09_sql.py
+++ b/tpcx_bb/queries/q09/tpcx_bb_query_09_sql.py
@@ -64,7 +64,7 @@ def read_tables(data_dir, bc):
     bc.create_table("customer_address", os.path.join(data_dir,  "/customer_address/*.parquet"))
     bc.create_table(
         "customer_demographics", os.path.join(data_dir,  "/customer_demographics/*.parquet"
-    )
+    ))
     bc.create_table("date_dim", os.path.join(data_dir,  "/date_dim/*.parquet"))
     bc.create_table("store", os.path.join(data_dir,  "/store/*.parquet"))
 

--- a/tpcx_bb/queries/q09/tpcx_bb_query_09_sql.py
+++ b/tpcx_bb/queries/q09/tpcx_bb_query_09_sql.py
@@ -60,13 +60,13 @@ q09_part3_sales_price_max = 200
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("store_sales", data_dir + "/store_sales/*.parquet")
-    bc.create_table("customer_address", data_dir + "/customer_address/*.parquet")
+    bc.create_table("store_sales", os.path.join(data_dir,  "/store_sales/*.parquet"))
+    bc.create_table("customer_address", os.path.join(data_dir,  "/customer_address/*.parquet"))
     bc.create_table(
-        "customer_demographics", data_dir + "/customer_demographics/*.parquet"
+        "customer_demographics", os.path.join(data_dir,  "/customer_demographics/*.parquet"
     )
-    bc.create_table("date_dim", data_dir + "/date_dim/*.parquet")
-    bc.create_table("store", data_dir + "/store/*.parquet")
+    bc.create_table("date_dim", os.path.join(data_dir,  "/date_dim/*.parquet"))
+    bc.create_table("store", os.path.join(data_dir,  "/store/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q10/tpcx_bb_query_10.py
+++ b/tpcx_bb/queries/q10/tpcx_bb_query_10.py
@@ -103,9 +103,9 @@ def main(client, config):
 
     # These files come from the official TPCx-BB kit
     # We extracted them from bigbenchqueriesmr.jar
-    sentiment_dir = "/".join(config["data_dir"].split("/")[:-3] + ["sentiment_files"])
-    neg_sent_df = load_sentiment_words(f"{sentiment_dir}/negativeSentiment.txt", "NEG")
-    pos_sent_df = load_sentiment_words(f"{sentiment_dir}/positiveSentiment.txt", "POS")
+    sentiment_dir = os.path.join(config["data_dir"], "sentiment_files")
+    neg_sent_df = load_sentiment_words(os.path.join(sentiment_dir, "/negativeSentiment.txt"), "NEG")
+    pos_sent_df = load_sentiment_words(os.path.join(sentiment_dir, "/positiveSentiment.txt"), "POS")
 
     sent_df = cudf.concat([pos_sent_df, neg_sent_df])
     sent_df = dask_cudf.from_cudf(sent_df, npartitions=1)

--- a/tpcx_bb/queries/q10/tpcx_bb_query_10.py
+++ b/tpcx_bb/queries/q10/tpcx_bb_query_10.py
@@ -15,7 +15,7 @@
 #
 
 import sys
-
+import os
 
 from xbb_tools.utils import (
     benchmark,
@@ -104,8 +104,8 @@ def main(client, config):
     # These files come from the official TPCx-BB kit
     # We extracted them from bigbenchqueriesmr.jar
     sentiment_dir = os.path.join(config["data_dir"], "sentiment_files")
-    neg_sent_df = load_sentiment_words(os.path.join(sentiment_dir, "/negativeSentiment.txt"), "NEG")
-    pos_sent_df = load_sentiment_words(os.path.join(sentiment_dir, "/positiveSentiment.txt"), "POS")
+    neg_sent_df = load_sentiment_words(os.path.join(sentiment_dir, "negativeSentiment.txt"), "NEG")
+    pos_sent_df = load_sentiment_words(os.path.join(sentiment_dir, "positiveSentiment.txt"), "POS")
 
     sent_df = cudf.concat([pos_sent_df, neg_sent_df])
     sent_df = dask_cudf.from_cudf(sent_df, npartitions=1)

--- a/tpcx_bb/queries/q10/tpcx_bb_query_10_sql.py
+++ b/tpcx_bb/queries/q10/tpcx_bb_query_10_sql.py
@@ -37,7 +37,7 @@ eol_char = "è"
 
 
 def read_tables(data_dir, bc):
-    bc.create_table('product_reviews', os.path.join(data_dir,  "product_reviews/*.parquet"))
+    bc.create_table('product_reviews', os.path.join(data_dir, "product_reviews/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q10/tpcx_bb_query_10_sql.py
+++ b/tpcx_bb/queries/q10/tpcx_bb_query_10_sql.py
@@ -16,9 +16,9 @@
 #
 
 import sys
+import os
 
 from xbb_tools.cluster_startup import attach_to_cluster
-import os
 
 from xbb_tools.utils import (
     benchmark,
@@ -90,10 +90,10 @@ def main(data_dir, client, bc, config):
     # Need to pass the absolute path for these txt files
     sentiment_dir = os.path.join(config["data_dir"], "sentiment_files")
     bc.create_table('negative_sentiment',
-                    os.path.join(sentiment_dir, "/negativeSentiment.txt"),
+                    os.path.join(sentiment_dir, "negativeSentiment.txt"),
                     names="sentiment_word")
     bc.create_table('positive_sentiment',
-                    os.path.join(sentiment_dir, "/positiveSentiment.txt"),
+                    os.path.join(sentiment_dir, "positiveSentiment.txt"),
                     names="sentiment_word")
 
     word_df = word_df.persist()

--- a/tpcx_bb/queries/q10/tpcx_bb_query_10_sql.py
+++ b/tpcx_bb/queries/q10/tpcx_bb_query_10_sql.py
@@ -37,7 +37,7 @@ eol_char = "è"
 
 
 def read_tables(data_dir, bc):
-    bc.create_table('product_reviews', data_dir + "product_reviews/*.parquet")
+    bc.create_table('product_reviews', os.path.join(data_dir,  "product_reviews/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q10/tpcx_bb_query_10_sql.py
+++ b/tpcx_bb/queries/q10/tpcx_bb_query_10_sql.py
@@ -88,12 +88,12 @@ def main(data_dir, client, bc, config):
     # These files come from the official TPCx-BB kit
     # We extracted them from bigbenchqueriesmr.jar
     # Need to pass the absolute path for these txt files
-    sentiment_dir = "/".join(config["data_dir"].split("/")[:-3] + ["sentiment_files"])
+    sentiment_dir = os.path.join(config["data_dir"], "sentiment_files")
     bc.create_table('negative_sentiment',
-                    sentiment_dir + "/negativeSentiment.txt",
+                    os.path.join(sentiment_dir, "/negativeSentiment.txt"),
                     names="sentiment_word")
     bc.create_table('positive_sentiment',
-                    sentiment_dir + "/positiveSentiment.txt",
+                    os.path.join(sentiment_dir, "/positiveSentiment.txt"),
                     names="sentiment_word")
 
     word_df = word_df.persist()

--- a/tpcx_bb/queries/q11/tpcx_bb_query_11_sql.py
+++ b/tpcx_bb/queries/q11/tpcx_bb_query_11_sql.py
@@ -33,9 +33,9 @@ from xbb_tools.utils import (
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("web_sales", data_dir + "/web_sales/*.parquet")
-    bc.create_table("product_reviews", data_dir + "/product_reviews/*.parquet")
-    bc.create_table("date_dim", data_dir + "/date_dim/*.parquet")
+    bc.create_table("web_sales", os.path.join(data_dir,  "/web_sales/*.parquet"))
+    bc.create_table("product_reviews", os.path.join(data_dir,  "/product_reviews/*.parquet"))
+    bc.create_table("date_dim", os.path.join(data_dir,  "/date_dim/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q11/tpcx_bb_query_11_sql.py
+++ b/tpcx_bb/queries/q11/tpcx_bb_query_11_sql.py
@@ -33,9 +33,9 @@ from xbb_tools.utils import (
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("web_sales", os.path.join(data_dir,  "/web_sales/*.parquet"))
-    bc.create_table("product_reviews", os.path.join(data_dir,  "/product_reviews/*.parquet"))
-    bc.create_table("date_dim", os.path.join(data_dir,  "/date_dim/*.parquet"))
+    bc.create_table("web_sales", os.path.join(data_dir, "web_sales/*.parquet"))
+    bc.create_table("product_reviews", os.path.join(data_dir, "product_reviews/*.parquet"))
+    bc.create_table("date_dim", os.path.join(data_dir, "date_dim/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q12/tpcx_bb_query_12.py
+++ b/tpcx_bb/queries/q12/tpcx_bb_query_12.py
@@ -15,6 +15,8 @@
 #
 
 import sys
+import os
+import glob
 
 from xbb_tools.utils import (
     benchmark,
@@ -25,7 +27,6 @@ from xbb_tools.readers import build_reader
 
 from distributed import wait
 import numpy as np
-import glob
 from dask import delayed
 
 ### Current Implementation Assumption
@@ -178,7 +179,7 @@ def main(client, config):
         "wcs_click_date_sk": np.ones(1, dtype=np.int64),
     }
     meta_df = cudf.DataFrame(meta_d)
-    web_clickstream_flist = glob.glob(config["data_dir"] + "web_clickstreams/*.parquet")
+    web_clickstream_flist = glob.glob(os.path.join(config["data_dir"], "web_clickstreams/*.parquet"))
     task_ls = [
         delayed(filter_wcs_table)(fn, filtered_item_df.to_delayed()[0])
         for fn in web_clickstream_flist

--- a/tpcx_bb/queries/q12/tpcx_bb_query_12_sql.py
+++ b/tpcx_bb/queries/q12/tpcx_bb_query_12_sql.py
@@ -32,9 +32,9 @@ q12_i_category_IN = "'Books', 'Electronics'"
 
 def read_tables(data_dir, bc):
     bc.create_table("web_clickstreams",
-                    data_dir + "/web_clickstreams/*.parquet")
-    bc.create_table("store_sales", data_dir + "/store_sales/*.parquet")
-    bc.create_table("item", data_dir + "/item/*.parquet")
+                    data_dir + "/web_clickstreams/*.parquet"))
+    bc.create_table("store_sales", os.path.join(data_dir,  "/store_sales/*.parquet"))
+    bc.create_table("item", os.path.join(data_dir,  "/item/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q12/tpcx_bb_query_12_sql.py
+++ b/tpcx_bb/queries/q12/tpcx_bb_query_12_sql.py
@@ -16,6 +16,7 @@
 #
 
 import sys
+import os
 
 from xbb_tools.cluster_startup import attach_to_cluster
 
@@ -32,8 +33,9 @@ q12_i_category_IN = "'Books', 'Electronics'"
 
 def read_tables(data_dir, bc):
     bc.create_table("web_clickstreams",
-                    data_dir + "/web_clickstreams/*.parquet"))
-    bc.create_table("store_sales", os.path.join(data_dir,  "/store_sales/*.parquet"))
+                    os.path.join(data_dir, "/web_clickstreams/*.parquet"))
+    bc.create_table("store_sales",
+                    os.path.join(data_dir,  "/store_sales/*.parquet"))
     bc.create_table("item", os.path.join(data_dir,  "/item/*.parquet"))
 
 

--- a/tpcx_bb/queries/q12/tpcx_bb_query_12_sql.py
+++ b/tpcx_bb/queries/q12/tpcx_bb_query_12_sql.py
@@ -33,10 +33,10 @@ q12_i_category_IN = "'Books', 'Electronics'"
 
 def read_tables(data_dir, bc):
     bc.create_table("web_clickstreams",
-                    os.path.join(data_dir, "/web_clickstreams/*.parquet"))
+                    os.path.join(data_dir, "web_clickstreams/*.parquet"))
     bc.create_table("store_sales",
-                    os.path.join(data_dir,  "/store_sales/*.parquet"))
-    bc.create_table("item", os.path.join(data_dir,  "/item/*.parquet"))
+                    os.path.join(data_dir, "store_sales/*.parquet"))
+    bc.create_table("item", os.path.join(data_dir, "item/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q13/tpcx_bb_query_13_sql.py
+++ b/tpcx_bb/queries/q13/tpcx_bb_query_13_sql.py
@@ -33,10 +33,10 @@ from xbb_tools.utils import (
 from dask.distributed import wait
 
 def read_tables(data_dir, bc):
-    bc.create_table("date_dim", data_dir + "/date_dim/*.parquet")
-    bc.create_table("customer", data_dir + "/customer/*.parquet")
-    bc.create_table("store_sales", data_dir + "/store_sales/*.parquet")
-    bc.create_table("web_sales", data_dir + "/web_sales/*.parquet")
+    bc.create_table("date_dim", os.path.join(data_dir,  "/date_dim/*.parquet"))
+    bc.create_table("customer", os.path.join(data_dir,  "/customer/*.parquet"))
+    bc.create_table("store_sales", os.path.join(data_dir,  "/store_sales/*.parquet"))
+    bc.create_table("web_sales", os.path.join(data_dir,  "/web_sales/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q13/tpcx_bb_query_13_sql.py
+++ b/tpcx_bb/queries/q13/tpcx_bb_query_13_sql.py
@@ -33,10 +33,10 @@ from xbb_tools.utils import (
 from dask.distributed import wait
 
 def read_tables(data_dir, bc):
-    bc.create_table("date_dim", os.path.join(data_dir,  "/date_dim/*.parquet"))
-    bc.create_table("customer", os.path.join(data_dir,  "/customer/*.parquet"))
-    bc.create_table("store_sales", os.path.join(data_dir,  "/store_sales/*.parquet"))
-    bc.create_table("web_sales", os.path.join(data_dir,  "/web_sales/*.parquet"))
+    bc.create_table("date_dim", os.path.join(data_dir, "date_dim/*.parquet"))
+    bc.create_table("customer", os.path.join(data_dir, "customer/*.parquet"))
+    bc.create_table("store_sales", os.path.join(data_dir, "store_sales/*.parquet"))
+    bc.create_table("web_sales", os.path.join(data_dir, "web_sales/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q14/tpcx_bb_query_14_sql.py
+++ b/tpcx_bb/queries/q14/tpcx_bb_query_14_sql.py
@@ -34,7 +34,7 @@ from xbb_tools.utils import (
 def read_tables(data_dir, bc):
     bc.create_table(
         "household_demographics", os.path.join(data_dir,  "/household_demographics/*.parquet"
-    )
+    ))
     bc.create_table("web_page", os.path.join(data_dir,  "/web_page/*.parquet"))
     bc.create_table("web_sales", os.path.join(data_dir,  "/web_sales/*.parquet"))
     bc.create_table("time_dim", os.path.join(data_dir,  "/time_dim/*.parquet"))

--- a/tpcx_bb/queries/q14/tpcx_bb_query_14_sql.py
+++ b/tpcx_bb/queries/q14/tpcx_bb_query_14_sql.py
@@ -33,11 +33,11 @@ from xbb_tools.utils import (
 
 def read_tables(data_dir, bc):
     bc.create_table(
-        "household_demographics", os.path.join(data_dir,  "/household_demographics/*.parquet"
+        "household_demographics", os.path.join(data_dir, "household_demographics/*.parquet"
     ))
-    bc.create_table("web_page", os.path.join(data_dir,  "/web_page/*.parquet"))
-    bc.create_table("web_sales", os.path.join(data_dir,  "/web_sales/*.parquet"))
-    bc.create_table("time_dim", os.path.join(data_dir,  "/time_dim/*.parquet"))
+    bc.create_table("web_page", os.path.join(data_dir, "web_page/*.parquet"))
+    bc.create_table("web_sales", os.path.join(data_dir, "web_sales/*.parquet"))
+    bc.create_table("time_dim", os.path.join(data_dir, "time_dim/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q14/tpcx_bb_query_14_sql.py
+++ b/tpcx_bb/queries/q14/tpcx_bb_query_14_sql.py
@@ -33,11 +33,11 @@ from xbb_tools.utils import (
 
 def read_tables(data_dir, bc):
     bc.create_table(
-        "household_demographics", data_dir + "/household_demographics/*.parquet"
+        "household_demographics", os.path.join(data_dir,  "/household_demographics/*.parquet"
     )
-    bc.create_table("web_page", data_dir + "/web_page/*.parquet")
-    bc.create_table("web_sales", data_dir + "/web_sales/*.parquet")
-    bc.create_table("time_dim", data_dir + "/time_dim/*.parquet")
+    bc.create_table("web_page", os.path.join(data_dir,  "/web_page/*.parquet"))
+    bc.create_table("web_sales", os.path.join(data_dir,  "/web_sales/*.parquet"))
+    bc.create_table("time_dim", os.path.join(data_dir,  "/time_dim/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q15/tpcx_bb_query_15_sql.py
+++ b/tpcx_bb/queries/q15/tpcx_bb_query_15_sql.py
@@ -37,9 +37,9 @@ q15_store_sk = 10
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("store_sales", os.path.join(data_dir,  "/store_sales/*.parquet"))
-    bc.create_table("date_dim", os.path.join(data_dir,  "/date_dim/*.parquet"))
-    bc.create_table("item", os.path.join(data_dir,  "/item/*.parquet"))
+    bc.create_table("store_sales", os.path.join(data_dir, "store_sales/*.parquet"))
+    bc.create_table("date_dim", os.path.join(data_dir, "date_dim/*.parquet"))
+    bc.create_table("item", os.path.join(data_dir, "item/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q15/tpcx_bb_query_15_sql.py
+++ b/tpcx_bb/queries/q15/tpcx_bb_query_15_sql.py
@@ -37,9 +37,9 @@ q15_store_sk = 10
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("store_sales", data_dir + "/store_sales/*.parquet")
-    bc.create_table("date_dim", data_dir + "/date_dim/*.parquet")
-    bc.create_table("item", data_dir + "/item/*.parquet")
+    bc.create_table("store_sales", os.path.join(data_dir,  "/store_sales/*.parquet"))
+    bc.create_table("date_dim", os.path.join(data_dir,  "/date_dim/*.parquet"))
+    bc.create_table("item", os.path.join(data_dir,  "/item/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q16/tpcx_bb_query_16_sql.py
+++ b/tpcx_bb/queries/q16/tpcx_bb_query_16_sql.py
@@ -34,11 +34,11 @@ from xbb_tools.utils import (
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("web_sales", data_dir + "/web_sales/*.parquet")
-    bc.create_table("web_returns", data_dir + "/web_returns/*.parquet")
-    bc.create_table("date_dim", data_dir + "/date_dim/*.parquet")
-    bc.create_table("item", data_dir + "/item/*.parquet")
-    bc.create_table("warehouse", data_dir + "/warehouse/*.parquet")
+    bc.create_table("web_sales", os.path.join(data_dir,  "/web_sales/*.parquet"))
+    bc.create_table("web_returns", os.path.join(data_dir,  "/web_returns/*.parquet"))
+    bc.create_table("date_dim", os.path.join(data_dir,  "/date_dim/*.parquet"))
+    bc.create_table("item", os.path.join(data_dir,  "/item/*.parquet"))
+    bc.create_table("warehouse", os.path.join(data_dir,  "/warehouse/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q16/tpcx_bb_query_16_sql.py
+++ b/tpcx_bb/queries/q16/tpcx_bb_query_16_sql.py
@@ -34,11 +34,11 @@ from xbb_tools.utils import (
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("web_sales", os.path.join(data_dir,  "/web_sales/*.parquet"))
-    bc.create_table("web_returns", os.path.join(data_dir,  "/web_returns/*.parquet"))
-    bc.create_table("date_dim", os.path.join(data_dir,  "/date_dim/*.parquet"))
-    bc.create_table("item", os.path.join(data_dir,  "/item/*.parquet"))
-    bc.create_table("warehouse", os.path.join(data_dir,  "/warehouse/*.parquet"))
+    bc.create_table("web_sales", os.path.join(data_dir, "web_sales/*.parquet"))
+    bc.create_table("web_returns", os.path.join(data_dir, "web_returns/*.parquet"))
+    bc.create_table("date_dim", os.path.join(data_dir, "date_dim/*.parquet"))
+    bc.create_table("item", os.path.join(data_dir, "item/*.parquet"))
+    bc.create_table("warehouse", os.path.join(data_dir, "warehouse/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q17/tpcx_bb_query_17_sql.py
+++ b/tpcx_bb/queries/q17/tpcx_bb_query_17_sql.py
@@ -35,13 +35,13 @@ q17_i_category_IN = "'Books', 'Music'"
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("store_sales", data_dir + "store_sales/*.parquet")
-    bc.create_table("item", data_dir + "item/*.parquet")
-    bc.create_table("customer", data_dir + "customer/*.parquet")
-    bc.create_table("store", data_dir + "store/*.parquet")
-    bc.create_table("date_dim", data_dir + "date_dim/*.parquet")
-    bc.create_table("customer_address", data_dir + "customer_address/*.parquet")
-    bc.create_table("promotion", data_dir + "promotion/*.parquet")
+    bc.create_table("store_sales", os.path.join(data_dir,  "store_sales/*.parquet"))
+    bc.create_table("item", os.path.join(data_dir,  "item/*.parquet"))
+    bc.create_table("customer", os.path.join(data_dir,  "customer/*.parquet"))
+    bc.create_table("store", os.path.join(data_dir,  "store/*.parquet"))
+    bc.create_table("date_dim", os.path.join(data_dir,  "date_dim/*.parquet"))
+    bc.create_table("customer_address", os.path.join(data_dir,  "customer_address/*.parquet"))
+    bc.create_table("promotion", os.path.join(data_dir,  "promotion/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q17/tpcx_bb_query_17_sql.py
+++ b/tpcx_bb/queries/q17/tpcx_bb_query_17_sql.py
@@ -16,6 +16,7 @@
 #
 
 import sys
+import os
 
 from xbb_tools.cluster_startup import attach_to_cluster
 

--- a/tpcx_bb/queries/q17/tpcx_bb_query_17_sql.py
+++ b/tpcx_bb/queries/q17/tpcx_bb_query_17_sql.py
@@ -35,13 +35,13 @@ q17_i_category_IN = "'Books', 'Music'"
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("store_sales", os.path.join(data_dir,  "store_sales/*.parquet"))
-    bc.create_table("item", os.path.join(data_dir,  "item/*.parquet"))
-    bc.create_table("customer", os.path.join(data_dir,  "customer/*.parquet"))
-    bc.create_table("store", os.path.join(data_dir,  "store/*.parquet"))
-    bc.create_table("date_dim", os.path.join(data_dir,  "date_dim/*.parquet"))
-    bc.create_table("customer_address", os.path.join(data_dir,  "customer_address/*.parquet"))
-    bc.create_table("promotion", os.path.join(data_dir,  "promotion/*.parquet"))
+    bc.create_table("store_sales", os.path.join(data_dir, "store_sales/*.parquet"))
+    bc.create_table("item", os.path.join(data_dir, "item/*.parquet"))
+    bc.create_table("customer", os.path.join(data_dir, "customer/*.parquet"))
+    bc.create_table("store", os.path.join(data_dir, "store/*.parquet"))
+    bc.create_table("date_dim", os.path.join(data_dir, "date_dim/*.parquet"))
+    bc.create_table("customer_address", os.path.join(data_dir, "customer_address/*.parquet"))
+    bc.create_table("promotion", os.path.join(data_dir, "promotion/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q18/tpcx_bb_query_18.py
+++ b/tpcx_bb/queries/q18/tpcx_bb_query_18.py
@@ -15,6 +15,8 @@
 #
 
 import sys
+import os
+
 from collections import OrderedDict
 
 from xbb_tools.utils import (
@@ -284,8 +286,8 @@ def main(client, config):
 
     # This file comes from the official TPCx-BB kit
     # We extracted it from bigbenchqueriesmr.jar
-    sentiment_dir = "/".join(config["data_dir"].split("/")[:-3] + ["sentiment_files"])
-    with open(f"{sentiment_dir}/negativeSentiment.txt") as fh:
+    sentiment_dir = os.path.join(config["data_dir"], "sentiment_files")
+    with open(os.path.join(sentiment_dir, "negativeSentiment.txt")) as fh:
         negativeSentiment = list(map(str.strip, fh.readlines()))
         # dedupe for one extra record in the source file
         negativeSentiment = list(set(negativeSentiment))
@@ -330,7 +332,6 @@ def main(client, config):
     final = final.sort_values(["s_name", "r_date", "r_sentence", "sentiment_word"])
     final = final.persist()
     wait(final)
-    print(len(final))
     return final
 
 

--- a/tpcx_bb/queries/q18/tpcx_bb_query_18_sql.py
+++ b/tpcx_bb/queries/q18/tpcx_bb_query_18_sql.py
@@ -256,7 +256,7 @@ def main(data_dir, client, bc, config):
     sentiment_dir = os.path.join(config["data_dir"], "sentiment_files")
     bc.create_table(
         "sent_df",
-        os.path.join(sentiment_dir, "/negativeSentiment.txt"),
+        os.path.join(sentiment_dir, "negativeSentiment.txt"),
         names=["sentiment_word"],
         dtype=["str"],
     )

--- a/tpcx_bb/queries/q18/tpcx_bb_query_18_sql.py
+++ b/tpcx_bb/queries/q18/tpcx_bb_query_18_sql.py
@@ -116,10 +116,10 @@ def find_relevant_reviews(df, targets, str_col_name="pr_review_content"):
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("store", data_dir + "store/*.parquet")
-    bc.create_table("store_sales", data_dir + "store_sales/*.parquet")
-    bc.create_table("date_dim", data_dir + "date_dim/*.parquet")
-    bc.create_table("product_reviews", data_dir + "product_reviews/*.parquet")
+    bc.create_table("store", os.path.join(data_dir,  "store/*.parquet"))
+    bc.create_table("store_sales", os.path.join(data_dir,  "store_sales/*.parquet"))
+    bc.create_table("date_dim", os.path.join(data_dir,  "date_dim/*.parquet"))
+    bc.create_table("product_reviews", os.path.join(data_dir,  "product_reviews/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q18/tpcx_bb_query_18_sql.py
+++ b/tpcx_bb/queries/q18/tpcx_bb_query_18_sql.py
@@ -116,10 +116,10 @@ def find_relevant_reviews(df, targets, str_col_name="pr_review_content"):
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("store", os.path.join(data_dir,  "store/*.parquet"))
-    bc.create_table("store_sales", os.path.join(data_dir,  "store_sales/*.parquet"))
-    bc.create_table("date_dim", os.path.join(data_dir,  "date_dim/*.parquet"))
-    bc.create_table("product_reviews", os.path.join(data_dir,  "product_reviews/*.parquet"))
+    bc.create_table("store", os.path.join(data_dir, "store/*.parquet"))
+    bc.create_table("store_sales", os.path.join(data_dir, "store_sales/*.parquet"))
+    bc.create_table("date_dim", os.path.join(data_dir, "date_dim/*.parquet"))
+    bc.create_table("product_reviews", os.path.join(data_dir, "product_reviews/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q18/tpcx_bb_query_18_sql.py
+++ b/tpcx_bb/queries/q18/tpcx_bb_query_18_sql.py
@@ -16,9 +16,9 @@
 #
 
 import sys
+import os
 
 from xbb_tools.cluster_startup import attach_to_cluster
-import os
 import numpy as np
 import cupy as cp
 

--- a/tpcx_bb/queries/q18/tpcx_bb_query_18_sql.py
+++ b/tpcx_bb/queries/q18/tpcx_bb_query_18_sql.py
@@ -253,10 +253,10 @@ def main(data_dir, client, bc, config):
     # This txt file comes from the official TPCx-BB kit
     # We extracted it from bigbenchqueriesmr.jar
     # Need to pass the absolute path for this txt file
-    sentiment_dir = "/".join(config["data_dir"].split("/")[:-3] + ["sentiment_files"])
+    sentiment_dir = os.path.join(config["data_dir"], "sentiment_files")
     bc.create_table(
         "sent_df",
-        sentiment_dir + "/negativeSentiment.txt",
+        os.path.join(sentiment_dir, "/negativeSentiment.txt"),
         names=["sentiment_word"],
         dtype=["str"],
     )

--- a/tpcx_bb/queries/q19/tpcx_bb_query_19.py
+++ b/tpcx_bb/queries/q19/tpcx_bb_query_19.py
@@ -15,6 +15,7 @@
 #
 
 import sys
+import os
 
 from xbb_tools.utils import (
     benchmark,

--- a/tpcx_bb/queries/q19/tpcx_bb_query_19.py
+++ b/tpcx_bb/queries/q19/tpcx_bb_query_19.py
@@ -162,8 +162,8 @@ def main(client, config):
 
     # This file comes from the official TPCx-BB kit
     # We extracted it from bigbenchqueriesmr.jar
-    sentiment_dir = "/".join(config["data_dir"].split("/")[:-3] + ["sentiment_files"])
-    with open(f"{sentiment_dir}/negativeSentiment.txt") as fh:
+    sentiment_dir = os.path.join(config["data_dir"], "sentiment_files")
+    with open(os.path.join(sentiment_dir, "negativeSentiment.txt")) as fh:
         negativeSentiment = list(map(str.strip, fh.readlines()))
         # dedupe for one extra record in the source file
         negativeSentiment = list(set(negativeSentiment))

--- a/tpcx_bb/queries/q19/tpcx_bb_query_19_sql.py
+++ b/tpcx_bb/queries/q19/tpcx_bb_query_19_sql.py
@@ -40,10 +40,10 @@ eol_char = "è"
 
 
 def read_tables(data_dir, bc):
-    bc.create_table('web_returns', os.path.join(data_dir,  "web_returns/*.parquet"))
-    bc.create_table('date_dim', os.path.join(data_dir,  "date_dim/*.parquet"))
-    bc.create_table('product_reviews', os.path.join(data_dir,  "product_reviews/*.parquet"))
-    bc.create_table('store_returns', os.path.join(data_dir,  "store_returns/*.parquet"))
+    bc.create_table('web_returns', os.path.join(data_dir, "web_returns/*.parquet"))
+    bc.create_table('date_dim', os.path.join(data_dir, "date_dim/*.parquet"))
+    bc.create_table('product_reviews', os.path.join(data_dir, "product_reviews/*.parquet"))
+    bc.create_table('store_returns', os.path.join(data_dir, "store_returns/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q19/tpcx_bb_query_19_sql.py
+++ b/tpcx_bb/queries/q19/tpcx_bb_query_19_sql.py
@@ -16,9 +16,9 @@
 #
 
 import sys
+import os
 
 from xbb_tools.cluster_startup import attach_to_cluster
-import os
 
 from xbb_tools.utils import (
     benchmark,

--- a/tpcx_bb/queries/q19/tpcx_bb_query_19_sql.py
+++ b/tpcx_bb/queries/q19/tpcx_bb_query_19_sql.py
@@ -116,8 +116,9 @@ def main(data_dir, client, bc, config):
     # This txt file comes from the official TPCx-BB kit
     # We extracted it from bigbenchqueriesmr.jar
     # Need to pass the absolute path for this txt file
-    sentiment_dir = "/".join(config["data_dir"].split("/")[:-3] + ["sentiment_files"])
-    bc.create_table('sent_df', sentiment_dir + "/negativeSentiment.txt",
+    sentiment_dir = os.path.join(config["data_dir"], "sentiment_files")
+    bc.create_table('sent_df',
+                    os.path.join(sentiment_dir, "negativeSentiment.txt"),
                     names=['sentiment_word'], dtype=['str'])
 
     sentences = sentences.persist()

--- a/tpcx_bb/queries/q19/tpcx_bb_query_19_sql.py
+++ b/tpcx_bb/queries/q19/tpcx_bb_query_19_sql.py
@@ -40,10 +40,10 @@ eol_char = "è"
 
 
 def read_tables(data_dir, bc):
-    bc.create_table('web_returns', data_dir + "web_returns/*.parquet")
-    bc.create_table('date_dim', data_dir + "date_dim/*.parquet")
-    bc.create_table('product_reviews', data_dir + "product_reviews/*.parquet")
-    bc.create_table('store_returns', data_dir + "store_returns/*.parquet")
+    bc.create_table('web_returns', os.path.join(data_dir,  "web_returns/*.parquet"))
+    bc.create_table('date_dim', os.path.join(data_dir,  "date_dim/*.parquet"))
+    bc.create_table('product_reviews', os.path.join(data_dir,  "product_reviews/*.parquet"))
+    bc.create_table('store_returns', os.path.join(data_dir,  "store_returns/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q20/tpcx_bb_query_20_sql.py
+++ b/tpcx_bb/queries/q20/tpcx_bb_query_20_sql.py
@@ -16,6 +16,7 @@
 #
 
 import sys
+import os
 
 from xbb_tools.cluster_startup import attach_to_cluster
 from dask import delayed

--- a/tpcx_bb/queries/q20/tpcx_bb_query_20_sql.py
+++ b/tpcx_bb/queries/q20/tpcx_bb_query_20_sql.py
@@ -61,8 +61,8 @@ def get_clusters(client, ml_input_df, feature_cols):
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("store_sales", os.path.join(data_dir,  "store_sales/*.parquet"))
-    bc.create_table("store_returns", os.path.join(data_dir,  "store_returns/*.parquet"))
+    bc.create_table("store_sales", os.path.join(data_dir, "store_sales/*.parquet"))
+    bc.create_table("store_returns", os.path.join(data_dir, "store_returns/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q20/tpcx_bb_query_20_sql.py
+++ b/tpcx_bb/queries/q20/tpcx_bb_query_20_sql.py
@@ -61,8 +61,8 @@ def get_clusters(client, ml_input_df, feature_cols):
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("store_sales", data_dir + "store_sales/*.parquet")
-    bc.create_table("store_returns", data_dir + "store_returns/*.parquet")
+    bc.create_table("store_sales", os.path.join(data_dir,  "store_sales/*.parquet"))
+    bc.create_table("store_returns", os.path.join(data_dir,  "store_returns/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q21/tpcx_bb_query_21_sql.py
+++ b/tpcx_bb/queries/q21/tpcx_bb_query_21_sql.py
@@ -16,6 +16,7 @@
 #
 
 import sys
+import os
 
 from xbb_tools.cluster_startup import attach_to_cluster
 

--- a/tpcx_bb/queries/q21/tpcx_bb_query_21_sql.py
+++ b/tpcx_bb/queries/q21/tpcx_bb_query_21_sql.py
@@ -27,12 +27,12 @@ from xbb_tools.utils import (
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("store_sales", os.path.join(data_dir,  "/store_sales/*.parquet"))
-    bc.create_table("date_dim", os.path.join(data_dir,  "/date_dim/*.parquet"))
-    bc.create_table("item", os.path.join(data_dir,  "/item/*.parquet"))
-    bc.create_table("web_sales", os.path.join(data_dir,  "/web_sales/*.parquet"))
-    bc.create_table("store_returns", os.path.join(data_dir,  "/store_returns/*.parquet"))
-    bc.create_table("store", os.path.join(data_dir,  "/store/*.parquet"))
+    bc.create_table("store_sales", os.path.join(data_dir, "store_sales/*.parquet"))
+    bc.create_table("date_dim", os.path.join(data_dir, "date_dim/*.parquet"))
+    bc.create_table("item", os.path.join(data_dir, "item/*.parquet"))
+    bc.create_table("web_sales", os.path.join(data_dir, "web_sales/*.parquet"))
+    bc.create_table("store_returns", os.path.join(data_dir, "store_returns/*.parquet"))
+    bc.create_table("store", os.path.join(data_dir, "store/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q21/tpcx_bb_query_21_sql.py
+++ b/tpcx_bb/queries/q21/tpcx_bb_query_21_sql.py
@@ -27,12 +27,12 @@ from xbb_tools.utils import (
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("store_sales", data_dir + "/store_sales/*.parquet")
-    bc.create_table("date_dim", data_dir + "/date_dim/*.parquet")
-    bc.create_table("item", data_dir + "/item/*.parquet")
-    bc.create_table("web_sales", data_dir + "/web_sales/*.parquet")
-    bc.create_table("store_returns", data_dir + "/store_returns/*.parquet")
-    bc.create_table("store", data_dir + "/store/*.parquet")
+    bc.create_table("store_sales", os.path.join(data_dir,  "/store_sales/*.parquet"))
+    bc.create_table("date_dim", os.path.join(data_dir,  "/date_dim/*.parquet"))
+    bc.create_table("item", os.path.join(data_dir,  "/item/*.parquet"))
+    bc.create_table("web_sales", os.path.join(data_dir,  "/web_sales/*.parquet"))
+    bc.create_table("store_returns", os.path.join(data_dir,  "/store_returns/*.parquet"))
+    bc.create_table("store", os.path.join(data_dir,  "/store/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q22/tpcx_bb_query_22_sql.py
+++ b/tpcx_bb/queries/q22/tpcx_bb_query_22_sql.py
@@ -16,6 +16,7 @@
 #
 
 import sys
+import os
 
 from xbb_tools.cluster_startup import attach_to_cluster
 

--- a/tpcx_bb/queries/q22/tpcx_bb_query_22_sql.py
+++ b/tpcx_bb/queries/q22/tpcx_bb_query_22_sql.py
@@ -33,10 +33,10 @@ q22_i_current_price_max = "1.5"
 
 
 def read_tables(data_dir, bc):
-    bc.create_table('inventory', data_dir + "inventory/*.parquet")
-    bc.create_table('item', data_dir + "item/*.parquet")
-    bc.create_table('warehouse', data_dir + "warehouse/*.parquet")
-    bc.create_table('date_dim', data_dir + "date_dim/*.parquet")
+    bc.create_table('inventory', os.path.join(data_dir,  "inventory/*.parquet"))
+    bc.create_table('item', os.path.join(data_dir,  "item/*.parquet"))
+    bc.create_table('warehouse', os.path.join(data_dir,  "warehouse/*.parquet"))
+    bc.create_table('date_dim', os.path.join(data_dir,  "date_dim/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q22/tpcx_bb_query_22_sql.py
+++ b/tpcx_bb/queries/q22/tpcx_bb_query_22_sql.py
@@ -33,10 +33,10 @@ q22_i_current_price_max = "1.5"
 
 
 def read_tables(data_dir, bc):
-    bc.create_table('inventory', os.path.join(data_dir,  "inventory/*.parquet"))
-    bc.create_table('item', os.path.join(data_dir,  "item/*.parquet"))
-    bc.create_table('warehouse', os.path.join(data_dir,  "warehouse/*.parquet"))
-    bc.create_table('date_dim', os.path.join(data_dir,  "date_dim/*.parquet"))
+    bc.create_table('inventory', os.path.join(data_dir, "inventory/*.parquet"))
+    bc.create_table('item', os.path.join(data_dir, "item/*.parquet"))
+    bc.create_table('warehouse', os.path.join(data_dir, "warehouse/*.parquet"))
+    bc.create_table('date_dim', os.path.join(data_dir, "date_dim/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q23/tpcx_bb_query_23_sql.py
+++ b/tpcx_bb/queries/q23/tpcx_bb_query_23_sql.py
@@ -16,6 +16,7 @@
 #
 
 import sys
+import os
 
 from xbb_tools.cluster_startup import attach_to_cluster
 

--- a/tpcx_bb/queries/q23/tpcx_bb_query_23_sql.py
+++ b/tpcx_bb/queries/q23/tpcx_bb_query_23_sql.py
@@ -34,8 +34,8 @@ q23_coefficient = 1.3
 
 
 def read_tables(data_dir, bc):
-    bc.create_table('inventory', os.path.join(data_dir,  "inventory/*.parquet"))
-    bc.create_table('date_dim', os.path.join(data_dir,  "date_dim/*.parquet"))
+    bc.create_table('inventory', os.path.join(data_dir, "inventory/*.parquet"))
+    bc.create_table('date_dim', os.path.join(data_dir, "date_dim/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q23/tpcx_bb_query_23_sql.py
+++ b/tpcx_bb/queries/q23/tpcx_bb_query_23_sql.py
@@ -34,8 +34,8 @@ q23_coefficient = 1.3
 
 
 def read_tables(data_dir, bc):
-    bc.create_table('inventory', data_dir + "inventory/*.parquet")
-    bc.create_table('date_dim', data_dir + "date_dim/*.parquet")
+    bc.create_table('inventory', os.path.join(data_dir,  "inventory/*.parquet"))
+    bc.create_table('date_dim', os.path.join(data_dir,  "date_dim/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q24/tpcx_bb_query_24_sql.py
+++ b/tpcx_bb/queries/q24/tpcx_bb_query_24_sql.py
@@ -32,10 +32,10 @@ from xbb_tools.utils import (
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("web_sales", data_dir + "/web_sales/*.parquet")
-    bc.create_table("item", data_dir + "/item/*.parquet")
-    bc.create_table("item_marketprices", data_dir + "/item_marketprices/*.parquet")
-    bc.create_table("store_sales", data_dir + "/store_sales/*.parquet")
+    bc.create_table("web_sales", os.path.join(data_dir,  "/web_sales/*.parquet"))
+    bc.create_table("item", os.path.join(data_dir,  "/item/*.parquet"))
+    bc.create_table("item_marketprices", os.path.join(data_dir,  "/item_marketprices/*.parquet"))
+    bc.create_table("store_sales", os.path.join(data_dir,  "/store_sales/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q24/tpcx_bb_query_24_sql.py
+++ b/tpcx_bb/queries/q24/tpcx_bb_query_24_sql.py
@@ -32,10 +32,10 @@ from xbb_tools.utils import (
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("web_sales", os.path.join(data_dir,  "/web_sales/*.parquet"))
-    bc.create_table("item", os.path.join(data_dir,  "/item/*.parquet"))
-    bc.create_table("item_marketprices", os.path.join(data_dir,  "/item_marketprices/*.parquet"))
-    bc.create_table("store_sales", os.path.join(data_dir,  "/store_sales/*.parquet"))
+    bc.create_table("web_sales", os.path.join(data_dir, "web_sales/*.parquet"))
+    bc.create_table("item", os.path.join(data_dir, "item/*.parquet"))
+    bc.create_table("item_marketprices", os.path.join(data_dir, "item_marketprices/*.parquet"))
+    bc.create_table("store_sales", os.path.join(data_dir, "store_sales/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q25/tpcx_bb_query_25_sql.py
+++ b/tpcx_bb/queries/q25/tpcx_bb_query_25_sql.py
@@ -59,9 +59,9 @@ def get_clusters(client, ml_input_df):
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("web_sales", data_dir + "web_sales/*.parquet")
-    bc.create_table("store_sales", data_dir + "store_sales/*.parquet")
-    bc.create_table("date_dim", data_dir + "date_dim/*.parquet")
+    bc.create_table("web_sales", os.path.join(data_dir,  "web_sales/*.parquet"))
+    bc.create_table("store_sales", os.path.join(data_dir,  "store_sales/*.parquet"))
+    bc.create_table("date_dim", os.path.join(data_dir,  "date_dim/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q25/tpcx_bb_query_25_sql.py
+++ b/tpcx_bb/queries/q25/tpcx_bb_query_25_sql.py
@@ -16,6 +16,7 @@
 #
 
 import sys
+import os
 
 from xbb_tools.cluster_startup import attach_to_cluster
 

--- a/tpcx_bb/queries/q25/tpcx_bb_query_25_sql.py
+++ b/tpcx_bb/queries/q25/tpcx_bb_query_25_sql.py
@@ -59,9 +59,9 @@ def get_clusters(client, ml_input_df):
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("web_sales", os.path.join(data_dir,  "web_sales/*.parquet"))
-    bc.create_table("store_sales", os.path.join(data_dir,  "store_sales/*.parquet"))
-    bc.create_table("date_dim", os.path.join(data_dir,  "date_dim/*.parquet"))
+    bc.create_table("web_sales", os.path.join(data_dir, "web_sales/*.parquet"))
+    bc.create_table("store_sales", os.path.join(data_dir, "store_sales/*.parquet"))
+    bc.create_table("date_dim", os.path.join(data_dir, "date_dim/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q26/tpcx_bb_query_26_sql.py
+++ b/tpcx_bb/queries/q26/tpcx_bb_query_26_sql.py
@@ -61,8 +61,8 @@ def get_clusters(client, kmeans_input_df):
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("store_sales", os.path.join(data_dir,  "store_sales/*.parquet"))
-    bc.create_table("item", os.path.join(data_dir,  "item/*.parquet"))
+    bc.create_table("store_sales", os.path.join(data_dir, "store_sales/*.parquet"))
+    bc.create_table("item", os.path.join(data_dir, "item/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q26/tpcx_bb_query_26_sql.py
+++ b/tpcx_bb/queries/q26/tpcx_bb_query_26_sql.py
@@ -16,6 +16,7 @@
 #
 
 import sys
+import os
 
 from xbb_tools.cluster_startup import attach_to_cluster
 

--- a/tpcx_bb/queries/q26/tpcx_bb_query_26_sql.py
+++ b/tpcx_bb/queries/q26/tpcx_bb_query_26_sql.py
@@ -61,8 +61,8 @@ def get_clusters(client, kmeans_input_df):
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("store_sales", data_dir + "store_sales/*.parquet")
-    bc.create_table("item", data_dir + "item/*.parquet")
+    bc.create_table("store_sales", os.path.join(data_dir,  "store_sales/*.parquet"))
+    bc.create_table("item", os.path.join(data_dir,  "item/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q27/tpcx_bb_query_27_sql.py
+++ b/tpcx_bb/queries/q27/tpcx_bb_query_27_sql.py
@@ -16,6 +16,7 @@
 #
 
 import sys
+import os
 
 from xbb_tools.text import (
     create_sentences_from_reviews,

--- a/tpcx_bb/queries/q27/tpcx_bb_query_27_sql.py
+++ b/tpcx_bb/queries/q27/tpcx_bb_query_27_sql.py
@@ -40,7 +40,7 @@ EOL_CHAR = "."
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("product_reviews", os.path.join(data_dir,  "/product_reviews/*.parquet"))
+    bc.create_table("product_reviews", os.path.join(data_dir, "product_reviews/*.parquet"))
 
 
 def ner_parser(df, col_string, batch_size=256):

--- a/tpcx_bb/queries/q27/tpcx_bb_query_27_sql.py
+++ b/tpcx_bb/queries/q27/tpcx_bb_query_27_sql.py
@@ -40,7 +40,7 @@ EOL_CHAR = "."
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("product_reviews", data_dir + "/product_reviews/*.parquet")
+    bc.create_table("product_reviews", os.path.join(data_dir,  "/product_reviews/*.parquet"))
 
 
 def ner_parser(df, col_string, batch_size=256):

--- a/tpcx_bb/queries/q28/tpcx_bb_query_28_sql.py
+++ b/tpcx_bb/queries/q28/tpcx_bb_query_28_sql.py
@@ -16,12 +16,13 @@
 #
 
 import sys
+import os
+import time
 
 from xbb_tools.cluster_startup import attach_to_cluster
 from cuml.feature_extraction.text import HashingVectorizer
 import cupy
 import dask
-import time
 from distributed import wait
 import cupy as cp
 import numpy as np

--- a/tpcx_bb/queries/q28/tpcx_bb_query_28_sql.py
+++ b/tpcx_bb/queries/q28/tpcx_bb_query_28_sql.py
@@ -297,7 +297,7 @@ def post_etl_processing(client, train_data, test_data):
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("product_reviews", data_dir + "product_reviews/*.parquet")
+    bc.create_table("product_reviews", os.path.join(data_dir,  "product_reviews/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q28/tpcx_bb_query_28_sql.py
+++ b/tpcx_bb/queries/q28/tpcx_bb_query_28_sql.py
@@ -297,7 +297,7 @@ def post_etl_processing(client, train_data, test_data):
 
 
 def read_tables(data_dir, bc):
-    bc.create_table("product_reviews", os.path.join(data_dir,  "product_reviews/*.parquet"))
+    bc.create_table("product_reviews", os.path.join(data_dir, "product_reviews/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q29/tpcx_bb_query_29_sql.py
+++ b/tpcx_bb/queries/q29/tpcx_bb_query_29_sql.py
@@ -32,8 +32,8 @@ q29_limit = 100
 
 
 def read_tables(data_dir, bc):
-    bc.create_table('item', os.path.join(data_dir,  "item/*.parquet"))
-    bc.create_table('web_sales', os.path.join(data_dir,  "web_sales/*.parquet"))
+    bc.create_table('item', os.path.join(data_dir, "item/*.parquet"))
+    bc.create_table('web_sales', os.path.join(data_dir, "web_sales/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q29/tpcx_bb_query_29_sql.py
+++ b/tpcx_bb/queries/q29/tpcx_bb_query_29_sql.py
@@ -32,8 +32,8 @@ q29_limit = 100
 
 
 def read_tables(data_dir, bc):
-    bc.create_table('item', data_dir + "item/*.parquet")
-    bc.create_table('web_sales', data_dir + "web_sales/*.parquet")
+    bc.create_table('item', os.path.join(data_dir,  "item/*.parquet"))
+    bc.create_table('web_sales', os.path.join(data_dir,  "web_sales/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q29/tpcx_bb_query_29_sql.py
+++ b/tpcx_bb/queries/q29/tpcx_bb_query_29_sql.py
@@ -16,6 +16,7 @@
 #
 
 import sys
+import os
 
 from xbb_tools.cluster_startup import attach_to_cluster
 

--- a/tpcx_bb/queries/q30/tpcx_bb_query_30.py
+++ b/tpcx_bb/queries/q30/tpcx_bb_query_30.py
@@ -16,6 +16,8 @@
 
 # Original code /tpcx-bb/tpcx-bb1.3.1/rapids-queries/q02/tpcx-bb-query-02.py
 import sys
+import glob
+import os
 
 from xbb_tools.utils import (
     benchmark,
@@ -26,11 +28,7 @@ from xbb_tools.readers import build_reader
 from xbb_tools.sessionization import get_session_id, get_distinct_sessions, get_pairs
 
 from dask import delayed
-
-### needed for set index
-import os
 import numpy as np
-import glob
 
 ### Implementation Notes:
 
@@ -112,7 +110,7 @@ def main(client, config):
     ### Below Pr has the dashboard snapshot which makes the problem clear
     ### https://github.com/rapidsai/tpcx-bb-internal/pull/496#issue-399946141
 
-    web_clickstream_flist = glob.glob(config["data_dir"] + "web_clickstreams/*.parquet")
+    web_clickstream_flist = glob.glob(os.path.join(config["data_dir"], "web_clickstreams/*.parquet"))
     task_ls = [
         delayed(pre_repartition_task)(fn, f_item_df.to_delayed()[0])
         for fn in web_clickstream_flist

--- a/tpcx_bb/queries/q30/tpcx_bb_query_30.py
+++ b/tpcx_bb/queries/q30/tpcx_bb_query_30.py
@@ -110,7 +110,7 @@ def main(client, config):
     ### Below Pr has the dashboard snapshot which makes the problem clear
     ### https://github.com/rapidsai/tpcx-bb-internal/pull/496#issue-399946141
 
-    web_clickstream_flist = glob.glob(os.path.join(config["data_dir"], "web_clickstreams/*.parquet")))
+    web_clickstream_flist = glob.glob(os.path.join(config["data_dir"], "web_clickstreams/*.parquet"))
     task_ls = [
         delayed(pre_repartition_task)(fn, f_item_df.to_delayed()[0])
         for fn in web_clickstream_flist

--- a/tpcx_bb/queries/q30/tpcx_bb_query_30.py
+++ b/tpcx_bb/queries/q30/tpcx_bb_query_30.py
@@ -110,7 +110,7 @@ def main(client, config):
     ### Below Pr has the dashboard snapshot which makes the problem clear
     ### https://github.com/rapidsai/tpcx-bb-internal/pull/496#issue-399946141
 
-    web_clickstream_flist = glob.glob(os.path.join(config["data_dir"], "web_clickstreams/*.parquet"))
+    web_clickstream_flist = glob.glob(os.path.join(config["data_dir"], "web_clickstreams/*.parquet")))
     task_ls = [
         delayed(pre_repartition_task)(fn, f_item_df.to_delayed()[0])
         for fn in web_clickstream_flist

--- a/tpcx_bb/queries/q30/tpcx_bb_query_30_sql.py
+++ b/tpcx_bb/queries/q30/tpcx_bb_query_30_sql.py
@@ -40,8 +40,8 @@ q30_limit = 40
 
 
 def read_tables(data_dir, bc):
-    bc.create_table('web_clickstreams', os.path.join(data_dir,  "web_clickstreams/*.parquet"))
-    bc.create_table('item', os.path.join(data_dir,  "item/*.parquet"))
+    bc.create_table('web_clickstreams', os.path.join(data_dir, "web_clickstreams/*.parquet"))
+    bc.create_table('item', os.path.join(data_dir, "item/*.parquet"))
 
 
 def main(data_dir, client, bc, config):

--- a/tpcx_bb/queries/q30/tpcx_bb_query_30_sql.py
+++ b/tpcx_bb/queries/q30/tpcx_bb_query_30_sql.py
@@ -16,6 +16,7 @@
 #
 
 import sys
+import os
 
 from xbb_tools.cluster_startup import attach_to_cluster
 

--- a/tpcx_bb/queries/q30/tpcx_bb_query_30_sql.py
+++ b/tpcx_bb/queries/q30/tpcx_bb_query_30_sql.py
@@ -40,8 +40,8 @@ q30_limit = 40
 
 
 def read_tables(data_dir, bc):
-    bc.create_table('web_clickstreams', data_dir + "web_clickstreams/*.parquet")
-    bc.create_table('item', data_dir + "item/*.parquet")
+    bc.create_table('web_clickstreams', os.path.join(data_dir,  "web_clickstreams/*.parquet"))
+    bc.create_table('item', os.path.join(data_dir,  "item/*.parquet"))
 
 
 def main(data_dir, client, bc, config):


### PR DESCRIPTION
This PR:
- Fixes all remaining unsafe uses of raw string concatenation for paths

Note that this PR changes where the `sentiment_files` directory for the sentiment analysis queries should be placed. It should now be placed inside the data directory itself.