### PR TITLE
[REVIEW] Remove q05 reset_index call that causes failures with dask null index

### DIFF
--- a/tpcx_bb/queries/q05/tpcx_bb_query_05.py
+++ b/tpcx_bb/queries/q05/tpcx_bb_query_05.py
@@ -181,7 +181,6 @@ def main(client, config):
     item_ddf["clicks_in_category"] = (
         (item_ddf["i_category"] == Q05_I_CATEGORY)
         .astype(np.int8)
-        .reset_index(drop=True)
     )
     keep_cols = ["i_item_sk", "i_category_id", "clicks_in_category"]
     item_ddf = item_ddf[keep_cols]


### PR DESCRIPTION
This PR:
- Removes a `reset_index(drop=True)` call on a Series that goes down the `__setitem__` codepath. This causes index alignment issues with the new(ish) `__dask_null_index__` that is generated in the data coming from our parquet writer scripts.

Verified correct without the reset index, so it's likely that it only is in the code due to an old bug in index handling that has since been resolved.

This closes #133 